### PR TITLE
Add ITIR enrichment and live ChatGPT sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,36 @@ mychatarchive serve
 
 The pipeline is incremental. Re-run `sync` any time -- SHA1 dedup means it's always safe. New messages get embedded on the next `embed` run without `--force`.
 
+### Required ITIR Enrichment
+
+MyChatArchive now expects a local `SensibLaw` checkout and attaches normalized
+token, structure, and relation metadata to every imported message. Ingest fails
+fast if that local shared-reducer surface is unavailable.
+
+Point the importer at one or more local checkouts in priority order:
+
+```bash
+export MYCHATARCHIVE_ITIR_PATHS="/path/to/SensibLaw:/path/to/fallback/SensibLaw"
+mychatarchive sync
+```
+
+You can also set the same paths in `~/.mychatarchive/config.json`:
+
+```json
+{
+  "itir": {
+    "paths": [
+      "/path/to/newer/SensibLaw",
+      "/path/to/fallback/SensibLaw"
+    ]
+  }
+}
+```
+
+If you keep multiple local checkouts, list the preferred one first. Existing
+canonical thread/message IDs remain stable; the extra metadata is additive and
+stored in the message `meta` field.
+
 ---
 
 ## Sync
@@ -171,9 +201,34 @@ mychatarchive sync --embed   # sync + generate embeddings in one shot
 
 1. **Auto-discovery** -- Claude Code sessions (`~/.claude/projects/`) and Cursor conversations from local databases. Enabled by default, toggleable in `init`.
 2. **Drop folder** -- anything in `~/.mychatarchive/imports/`. Drop your ChatGPT, Claude, or Grok export JSON here; format is auto-detected. Subdirectories scanned recursively.
-3. **Named sources** -- custom paths or NAS shares you've configured with `mychatarchive sources add`.
+3. **Named sources** -- path sources via `mychatarchive sources add`, plus live ChatGPT-backed sources via `mychatarchive sources add-live`.
 
 All three deduplicate into the same archive via SHA1 hashing.
+
+### Live Sources
+
+Configure a live source when you want `sync` or `import --from` to pull a
+conversation directly from ChatGPT using a DB-first selector policy and a live
+fallback only when the archive cannot disambiguate the selector.
+
+```bash
+mychatarchive sources add-live project-chat "Project chat"
+mychatarchive sources add-live product-thread "https://chatgpt.com/c/1234..." --title "Product thread"
+mychatarchive import --from project-chat
+```
+
+Live sources preserve upstream `source_thread_id` and `source_message_id`
+provenance in the archive.
+
+### NotebookLM
+
+The sibling `../notebooklm-pack` workflow is exposed directly:
+
+```bash
+mychatarchive notebooklm pack ../_repo_readmes /tmp/mca-pack
+mychatarchive notebooklm ingest --manifest /tmp/mca-pack/manifest.json --notebook-url https://notebooklm.google.com/notebook/NOTEBOOK_ID --output /tmp/mca-ingest.json
+mychatarchive notebooklm pack-ingest ../_repo_readmes /tmp/mca-pack --notebook-title "MyChatArchive Context" --output /tmp/mca-ingest.json
+```
 
 > **Note:** Auto-discovery covers Claude Code (the terminal agent) and Cursor. Claude web, mobile, and desktop app conversations require a manual export from Anthropic's settings -- drop the file in your imports folder and run `sync`.
 
@@ -352,9 +407,13 @@ Named sources (NAS, custom paths)     --+              |
 | `mychatarchive import <file\|dir>` | Import a single file or directory |
 | `mychatarchive import --from <name>` | Import from a named source |
 | `mychatarchive sources add <name> <path>` | Add a named import source |
+| `mychatarchive sources add-live <name> <selector>` | Add a named live source |
 | `mychatarchive sources list` | Show all sources (auto + drop + named) |
 | `mychatarchive sources remove <name>` | Remove a source |
 | `mychatarchive sources rename <old> <new>` | Rename a source |
+| `mychatarchive notebooklm pack ...` | Run sibling `notebooklm-pack` |
+| `mychatarchive notebooklm ingest ...` | Upload a `manifest.json` to NotebookLM |
+| `mychatarchive notebooklm pack-ingest ...` | Pack then upload in one command |
 | `mychatarchive summarize` | Generate LLM thread summaries (needs API key) |
 | `mychatarchive groups list` | List all thread groups |
 | `mychatarchive groups create <name>` | Create a thread group |

--- a/src/mychatarchive/backends/storage/__init__.py
+++ b/src/mychatarchive/backends/storage/__init__.py
@@ -25,6 +25,9 @@ class StorageBackend(Protocol):
         self, con, message_id: str, canonical_thread_id: str,
         platform: str, account_id: str, ts: str, role: str,
         text: str, title: str, source_id: str,
+        source_thread_id: Optional[str] = None,
+        source_message_id: Optional[str] = None,
+        meta: Optional[dict] = None,
     ) -> bool: ...
 
     # Counts

--- a/src/mychatarchive/backends/storage/sqlite.py
+++ b/src/mychatarchive/backends/storage/sqlite.py
@@ -28,6 +28,8 @@ def get_connection(db_path: Path) -> sqlite3.Connection:
     sqlite_vec.load(con)
     con.enable_load_extension(False)
     con.execute("PRAGMA journal_mode=WAL")
+    con.execute("PRAGMA synchronous=NORMAL")
+    con.execute("PRAGMA temp_store=MEMORY")
     return con
 
 
@@ -117,6 +119,25 @@ def _ensure_thread_summaries_v2(con: sqlite3.Connection, dim: int) -> None:
     con.commit()
 
 
+def _ensure_message_meta_column(con: sqlite3.Connection) -> None:
+    cols = {row[1] for row in con.execute("PRAGMA table_info(messages)").fetchall()}
+    if cols and "meta" not in cols:
+        con.execute("ALTER TABLE messages ADD COLUMN meta TEXT")
+        con.commit()
+
+
+def _ensure_message_provenance_columns(con: sqlite3.Connection) -> None:
+    cols = {row[1] for row in con.execute("PRAGMA table_info(messages)").fetchall()}
+    if cols and "source_thread_id" not in cols:
+        con.execute("ALTER TABLE messages ADD COLUMN source_thread_id TEXT")
+    if cols and "source_message_id" not in cols:
+        con.execute("ALTER TABLE messages ADD COLUMN source_message_id TEXT")
+    con.execute(
+        "CREATE INDEX IF NOT EXISTS idx_messages_source_thread_id ON messages(source_thread_id)"
+    )
+    con.commit()
+
+
 def ensure_schema(con: sqlite3.Connection):
     """Create all tables (ingestion + brain). Idempotent."""
     dim = _get_embedding_dim()
@@ -133,7 +154,10 @@ def ensure_schema(con: sqlite3.Connection):
             role TEXT NOT NULL,
             text TEXT NOT NULL,
             title TEXT,
-            source_id TEXT NOT NULL
+            source_id TEXT NOT NULL,
+            source_thread_id TEXT,
+            source_message_id TEXT,
+            meta TEXT
         );
 
         CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts
@@ -190,6 +214,8 @@ def ensure_schema(con: sqlite3.Connection):
     """)
 
     con.commit()
+    _ensure_message_meta_column(con)
+    _ensure_message_provenance_columns(con)
 
     # Thread summaries: create or migrate to multi-segment schema
     _ensure_thread_summaries_v2(con, dim)
@@ -199,18 +225,36 @@ def ensure_schema(con: sqlite3.Connection):
 
 def insert_message(con: sqlite3.Connection, message_id: str, canonical_thread_id: str,
                    platform: str, account_id: str, ts: str, role: str, text: str,
-                   title: str, source_id: str) -> bool:
+                   title: str, source_id: str,
+                   source_thread_id: Optional[str] = None,
+                   source_message_id: Optional[str] = None,
+                   meta: Optional[dict] = None) -> bool:
     """Insert a message. Returns True if inserted, False if duplicate."""
     cur = con.execute(
         "INSERT OR IGNORE INTO messages "
-        "(message_id, canonical_thread_id, platform, account_id, ts, role, text, title, source_id) "
-        "VALUES (?,?,?,?,?,?,?,?,?)",
-        (message_id, canonical_thread_id, platform, account_id, ts, role, text, title, source_id),
+        "("
+        "message_id, canonical_thread_id, platform, account_id, ts, role, text, title, source_id, "
+        "source_thread_id, source_message_id, meta"
+        ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+        (
+            message_id,
+            canonical_thread_id,
+            platform,
+            account_id,
+            ts,
+            role,
+            text,
+            title,
+            source_id,
+            source_thread_id,
+            source_message_id,
+            json.dumps(meta) if meta else None,
+        ),
     )
     if cur.rowcount == 0:
         return False
-    con.execute("INSERT INTO messages_fts (text) VALUES (?)", (text,))
-    fts_rowid = con.execute("SELECT max(rowid) FROM messages_fts").fetchone()[0]
+    fts_cur = con.execute("INSERT INTO messages_fts (text) VALUES (?)", (text,))
+    fts_rowid = fts_cur.lastrowid
     con.execute(
         "INSERT INTO messages_fts_docids (rowid, message_id) VALUES (?,?)",
         (fts_rowid, message_id),
@@ -253,7 +297,8 @@ def platform_counts(con: sqlite3.Connection) -> list[tuple[str, int]]:
 def iter_messages(con: sqlite3.Connection, batch_size: int = 1000):
     cur = con.cursor()
     cur.execute("""
-        SELECT message_id, canonical_thread_id, ts, role, text, title
+        SELECT message_id, canonical_thread_id, ts, role, text, title,
+               source_thread_id, source_message_id, meta
         FROM messages ORDER BY canonical_thread_id, ts
     """)
     while True:
@@ -268,6 +313,9 @@ def iter_messages(con: sqlite3.Connection, batch_size: int = 1000):
                 "role": row[3],
                 "text": row[4],
                 "title": row[5],
+                "source_thread_id": row[6],
+                "source_message_id": row[7],
+                "meta": json.loads(row[8]) if row[8] else None,
             }
 
 
@@ -507,7 +555,7 @@ def export_messages(con: sqlite3.Connection, platform: Optional[str] = None,
                     limit: Optional[int] = None):
     query = """
         SELECT message_id, canonical_thread_id, platform, account_id,
-               ts, role, text, title, source_id
+               ts, role, text, title, source_id, source_thread_id, source_message_id, meta
         FROM messages ORDER BY platform, canonical_thread_id, ts
     """
     params: list = []
@@ -520,7 +568,9 @@ def export_messages(con: sqlite3.Connection, platform: Optional[str] = None,
     rows = con.execute(query, params).fetchall()
     return [
         {"message_id": r[0], "thread_id": r[1], "platform": r[2], "account_id": r[3],
-         "timestamp": r[4], "role": r[5], "content": r[6], "title": r[7], "source_id": r[8]}
+         "timestamp": r[4], "role": r[5], "content": r[6], "title": r[7], "source_id": r[8],
+         "source_thread_id": r[9], "source_message_id": r[10],
+         "meta": json.loads(r[11]) if r[11] else None}
         for r in rows
     ]
 

--- a/src/mychatarchive/cli.py
+++ b/src/mychatarchive/cli.py
@@ -12,6 +12,7 @@ Commands:
     mychatarchive search <query>      Search from the command line
     mychatarchive info                Show archive stats
     mychatarchive mcp-config          Print MCP configuration JSON
+    mychatarchive notebooklm          Pack or ingest NotebookLM source bundles
 """
 
 import argparse
@@ -61,6 +62,13 @@ def main():
     sources_add.add_argument("path", help="Path to file or directory")
     sources_add.add_argument("--format", default=None, help="Force format (chatgpt, anthropic, etc.)")
     sources_add.add_argument("--account", default="main", help="Account identifier")
+
+    sources_add_live = sources_sub.add_parser("add-live", help="Add a named live import source")
+    sources_add_live.add_argument("name", help="Source name (e.g. 'chatgpt-live')")
+    sources_add_live.add_argument("selector", help="Conversation id, URL, or title selector")
+    sources_add_live.add_argument("--provider", default="chatgpt", help="Live provider name")
+    sources_add_live.add_argument("--account", default="main", help="Account identifier")
+    sources_add_live.add_argument("--title", default=None, help="Optional display title")
 
     sources_rm = sources_sub.add_parser("remove", help="Remove a source")
     sources_rm.add_argument("name", help="Source name to remove")
@@ -279,6 +287,37 @@ def main():
     )
     _add_db_arg(mcp_p)
 
+    # --- notebooklm ---
+    notebooklm_p = sub.add_parser("notebooklm", help="Pack and ingest NotebookLM source bundles")
+    notebooklm_sub = notebooklm_p.add_subparsers(dest="notebooklm_command")
+
+    notebooklm_pack = notebooklm_sub.add_parser("pack", help="Run sibling notebooklm-pack")
+    notebooklm_pack.add_argument("repo_list", help="Repo list file or scan root")
+    notebooklm_pack.add_argument("output_dir", help="Output directory for packed sources")
+    notebooklm_pack.add_argument("--max-sources", type=int, default=50, help="Max sources to emit")
+
+    notebooklm_ingest = notebooklm_sub.add_parser("ingest", help="Upload a notebooklm-pack manifest")
+    notebooklm_ingest.add_argument("--manifest", required=True, help="Path to manifest.json")
+    notebooklm_ingest.add_argument("--notebook-id", default=None, help="Existing notebook id")
+    notebooklm_ingest.add_argument("--notebook-url", default=None, help="Existing notebook URL")
+    notebooklm_ingest.add_argument("--notebook-title", default=None, help="Notebook title if creating")
+    notebooklm_ingest.add_argument("--wait-timeout", type=int, default=None, help="Per-source wait timeout")
+    notebooklm_ingest.add_argument("--upload-concurrency", type=int, default=None, help="Upload concurrency")
+    notebooklm_ingest.add_argument("--notebooklm-cli", default=None, help="Path to notebooklm CLI")
+    notebooklm_ingest.add_argument("--output", required=True, help="Output JSON path")
+
+    notebooklm_pack_ingest = notebooklm_sub.add_parser("pack-ingest", help="Pack then upload to NotebookLM")
+    notebooklm_pack_ingest.add_argument("repo_list", help="Repo list file or scan root")
+    notebooklm_pack_ingest.add_argument("output_dir", help="Output directory for packed sources")
+    notebooklm_pack_ingest.add_argument("--max-sources", type=int, default=50, help="Max sources to emit")
+    notebooklm_pack_ingest.add_argument("--notebook-id", default=None, help="Existing notebook id")
+    notebooklm_pack_ingest.add_argument("--notebook-url", default=None, help="Existing notebook URL")
+    notebooklm_pack_ingest.add_argument("--notebook-title", default=None, help="Notebook title if creating")
+    notebooklm_pack_ingest.add_argument("--wait-timeout", type=int, default=None, help="Per-source wait timeout")
+    notebooklm_pack_ingest.add_argument("--upload-concurrency", type=int, default=None, help="Upload concurrency")
+    notebooklm_pack_ingest.add_argument("--notebooklm-cli", default=None, help="Path to notebooklm CLI")
+    notebooklm_pack_ingest.add_argument("--output", required=True, help="Output JSON path")
+
     args = parser.parse_args()
 
     if args.command is None:
@@ -291,6 +330,10 @@ def main():
 
     if args.command == "sources":
         _cmd_sources(args)
+        return
+
+    if args.command == "notebooklm":
+        _cmd_notebooklm(args)
         return
 
     db_path = args.db or get_db_path()
@@ -501,7 +544,7 @@ def _cmd_sync(args, db_path: Path):
 
 
 def _cmd_sources(args):
-    from mychatarchive.config import get_sources, add_source, remove_source, rename_source
+    from mychatarchive.config import add_live_source, add_source, remove_source, rename_source
 
     cmd = args.sources_command
 
@@ -515,6 +558,21 @@ def _cmd_sources(args):
         if args.format:
             print(f"  Format: {args.format}")
         print(f"  Account: {args.account}")
+        print(f"\nUse: mychatarchive import --from {args.name}")
+
+    elif cmd == "add-live":
+        add_live_source(
+            args.name,
+            args.selector,
+            provider=args.provider,
+            account=args.account,
+            title=args.title,
+        )
+        print(f"Live source '{args.name}' added: {args.selector}")
+        print(f"  Provider: {args.provider}")
+        print(f"  Account:  {args.account}")
+        if args.title:
+            print(f"  Title:    {args.title}")
         print(f"\nUse: mychatarchive import --from {args.name}")
 
     elif cmd == "remove":
@@ -569,13 +627,21 @@ def _cmd_sources_list():
         print()
         print(f"  NAMED SOURCES ({len(sources)}):")
         for name, cfg in sources.items():
-            path = cfg.get("path", "?")
-            fmt = cfg.get("format", "auto-detect")
+            source_type = cfg.get("type", "path")
             account = cfg.get("account", "main")
-            exists = "✓" if Path(path).expanduser().exists() else "✗"
             print(f"    {name}")
-            print(f"      Path:    {path} [{exists}]")
-            print(f"      Format:  {fmt}")
+            print(f"      Type:    {source_type}")
+            if source_type == "live":
+                print(f"      Provider: {cfg.get('provider', 'chatgpt')}")
+                print(f"      Selector: {cfg.get('selector', '?')}")
+                if cfg.get("title"):
+                    print(f"      Title:    {cfg.get('title')}")
+            else:
+                path = cfg.get("path", "?")
+                fmt = cfg.get("format", "auto-detect")
+                exists = "✓" if Path(path).expanduser().exists() else "✗"
+                print(f"      Path:    {path} [{exists}]")
+                print(f"      Format:  {fmt}")
             print(f"      Account: {account}")
 
     print(f"{'─' * 60}")
@@ -707,14 +773,21 @@ def _cmd_export(args, db_path: Path):
 
     elif fmt == "csv":
         import csv
+        csv_rows = []
+        for message in messages:
+            row = dict(message)
+            if row.get("meta") is not None:
+                row["meta"] = json.dumps(row["meta"], ensure_ascii=False)
+            csv_rows.append(row)
         with open(output_path, "w", encoding="utf-8", newline="") as f:
             writer = csv.DictWriter(
                 f,
                 fieldnames=["message_id", "thread_id", "platform", "account_id",
-                            "timestamp", "role", "content", "title", "source_id"],
+                            "timestamp", "role", "content", "title", "source_id",
+                            "source_thread_id", "source_message_id", "meta"],
             )
             writer.writeheader()
-            writer.writerows(messages)
+            writer.writerows(csv_rows)
 
         print(f"Exported {len(messages):,} messages to {output_path}")
         if thoughts and args.include_thoughts:
@@ -727,6 +800,51 @@ def _cmd_export(args, db_path: Path):
                 writer.writeheader()
                 writer.writerows(thoughts)
             print(f"  + {len(thoughts):,} thoughts to {thought_path}")
+
+
+def _cmd_notebooklm(args):
+    import subprocess
+
+    repo_root = Path(__file__).resolve().parents[2]
+    notebooklm_pack_repo = repo_root.parent / "notebooklm-pack"
+    pack_bin = notebooklm_pack_repo / "target" / "debug" / "notebooklm-pack"
+    ingest_script = notebooklm_pack_repo / "scripts" / "ingest_manifest.py"
+
+    if args.notebooklm_command is None:
+        print("Use one of: pack, ingest, pack-ingest", file=sys.stderr)
+        sys.exit(1)
+
+    def _run(cmd: list[str]):
+        proc = subprocess.run(cmd, check=False)
+        if proc.returncode != 0:
+            raise SystemExit(proc.returncode)
+
+    if args.notebooklm_command in {"pack", "pack-ingest"}:
+        if not pack_bin.exists():
+            print(f"notebooklm-pack binary not found: {pack_bin}", file=sys.stderr)
+            sys.exit(1)
+        cmd = [str(pack_bin), args.repo_list, args.output_dir, "--max-sources", str(args.max_sources)]
+        _run(cmd)
+
+    if args.notebooklm_command in {"ingest", "pack-ingest"}:
+        manifest = getattr(args, "manifest", None) or str(Path(args.output_dir) / "manifest.json")
+        if not ingest_script.exists():
+            print(f"NotebookLM ingest helper not found: {ingest_script}", file=sys.stderr)
+            sys.exit(1)
+        cmd = [sys.executable, str(ingest_script), "--manifest", manifest, "--output", args.output]
+        if args.notebook_id:
+            cmd.extend(["--notebook-id", args.notebook_id])
+        if args.notebook_url:
+            cmd.extend(["--notebook-url", args.notebook_url])
+        if args.notebook_title:
+            cmd.extend(["--notebook-title", args.notebook_title])
+        if args.wait_timeout is not None:
+            cmd.extend(["--wait-timeout", str(args.wait_timeout)])
+        if args.upload_concurrency is not None:
+            cmd.extend(["--upload-concurrency", str(args.upload_concurrency)])
+        if args.notebooklm_cli:
+            cmd.extend(["--notebooklm-cli", args.notebooklm_cli])
+        _run(cmd)
 
 
 def _cmd_embed(args, db_path: Path):

--- a/src/mychatarchive/config.py
+++ b/src/mychatarchive/config.py
@@ -11,7 +11,8 @@ Example config.json:
   "drop_folder": "~/.mychatarchive/imports",
   "auto_sources": {"claude_code": true, "cursor": true},
   "sources": {
-    "nas": {"path": "//server.local/share/exports", "format": "chatgpt"}
+    "nas": {"type": "path", "path": "//server.local/share/exports", "format": "chatgpt"},
+    "chatgpt_live": {"type": "live", "provider": "chatgpt", "selector": "Project chat"}
   },
   "summarize": {
     "api_key": "sk-or-...",
@@ -23,6 +24,7 @@ Example config.json:
 """
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -168,9 +170,30 @@ def get_source(name: str) -> dict | None:
 def add_source(name: str, path: str, format_name: str | None = None, account: str = "main"):
     cfg = load_config()
     sources = cfg.setdefault("sources", {})
-    entry: dict = {"path": path, "account": account}
+    entry: dict = {"type": "path", "path": path, "account": account}
     if format_name:
         entry["format"] = format_name
+    sources[name] = entry
+    save_config(cfg)
+
+
+def add_live_source(
+    name: str,
+    selector: str,
+    provider: str = "chatgpt",
+    account: str = "main",
+    title: str | None = None,
+):
+    cfg = load_config()
+    sources = cfg.setdefault("sources", {})
+    entry: dict = {
+        "type": "live",
+        "provider": provider,
+        "selector": selector,
+        "account": account,
+    }
+    if title:
+        entry["title"] = title
     sources[name] = entry
     save_config(cfg)
 
@@ -193,3 +216,41 @@ def rename_source(old_name: str, new_name: str) -> bool:
     sources[new_name] = sources.pop(old_name)
     save_config(cfg)
     return True
+
+
+def get_itir_paths() -> list[Path]:
+    """Return configured ITIR/SensibLaw roots in priority order."""
+    cfg = load_config()
+    configured = cfg.get("itir", {}).get("paths", [])
+    if configured:
+        return [Path(path).expanduser() for path in configured]
+
+    env_value = os.environ.get("MYCHATARCHIVE_ITIR_PATHS", "").strip()
+    if env_value:
+        return [Path(path).expanduser() for path in env_value.split(os.pathsep) if path.strip()]
+
+    repo_root = Path(__file__).resolve().parents[2]
+    defaults = [
+        repo_root.parent / "ITIR-suite" / "SensibLaw",
+        Path.home() / "Documents" / "code" / "ITIR-suite" / "SensibLaw",
+    ]
+    return [path for path in defaults if path.exists()]
+
+
+def get_re_gpt_roots() -> list[Path]:
+    """Return candidate reverse-engineered-chatgpt roots in priority order."""
+    cfg = load_config()
+    configured = cfg.get("live", {}).get("re_gpt_paths", [])
+    if configured:
+        return [Path(path).expanduser() for path in configured]
+
+    env_value = os.environ.get("MYCHATARCHIVE_RE_GPT_PATHS", "").strip()
+    if env_value:
+        return [Path(path).expanduser() for path in env_value.split(os.pathsep) if path.strip()]
+
+    repo_root = Path(__file__).resolve().parents[2]
+    defaults = [
+        repo_root.parent / "ITIR-suite" / "reverse-engineered-chatgpt",
+        Path.home() / "Documents" / "code" / "ITIR-suite" / "reverse-engineered-chatgpt",
+    ]
+    return [path for path in defaults if path.exists()]

--- a/src/mychatarchive/db.py
+++ b/src/mychatarchive/db.py
@@ -30,10 +30,13 @@ def ensure_schema(con) -> None:
 
 def insert_message(con, message_id: str, canonical_thread_id: str,
                    platform: str, account_id: str, ts: str, role: str,
-                   text: str, title: str, source_id: str) -> bool:
+                   text: str, title: str, source_id: str,
+                   source_thread_id: Optional[str] = None,
+                   source_message_id: Optional[str] = None,
+                   meta: Optional[dict] = None) -> bool:
     return _b().insert_message(
         con, message_id, canonical_thread_id, platform, account_id,
-        ts, role, text, title, source_id,
+        ts, role, text, title, source_id, source_thread_id, source_message_id, meta,
     )
 
 

--- a/src/mychatarchive/ingest.py
+++ b/src/mychatarchive/ingest.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from tqdm import tqdm
 
 from mychatarchive import db
+from mychatarchive.itir import enrich_text as enrich_text_with_itir
+from mychatarchive.live import choose_live_selector, fetch_live_messages
 from mychatarchive.parsers import parse, detect_format
 
 IMPORTABLE_EXTENSIONS = {".json", ".jsonl"}
@@ -46,6 +48,121 @@ def round_epoch(ts) -> int | None:
         return None
 
 
+def _build_message_meta(content: str | None) -> dict | None:
+    if not content or not content.strip():
+        return None
+    itir_payload = enrich_text_with_itir(content)
+    return {"itir": itir_payload}
+
+
+def _canonical_thread_id_for_messages(
+    thread_messages: list[dict],
+    *,
+    platform: str,
+    account_id: str,
+) -> str:
+    first = thread_messages[0]
+    thread_source_id = str(first.get("thread_id") or "").strip()
+    if thread_source_id:
+        return sha1("|".join([platform, account_id, "source_thread_id", thread_source_id]))
+
+    first_snip = (first["content"] or "")[:256]
+    return sha1("|".join([
+        platform,
+        account_id,
+        norm_text(first["thread_title"]),
+        str(round_epoch(first["created_at"]) or ""),
+        first["role"] or "",
+        norm_text(first_snip),
+    ]))
+
+
+def _message_id_for_message(
+    msg: dict,
+    *,
+    platform: str,
+    account_id: str,
+    canonical_thread_id: str,
+) -> str:
+    source_message_id = str(msg.get("source_message_id") or "").strip()
+    if source_message_id:
+        return sha1("|".join([
+            platform, account_id, canonical_thread_id, "source_message_id", source_message_id,
+        ]))
+
+    ts_round = round_epoch(msg["created_at"]) or 0
+    return sha1("|".join([
+        platform, account_id, canonical_thread_id, msg["role"] or "",
+        str(ts_round), norm_text(msg["content"] or ""),
+    ]))
+
+
+def ingest_parsed_messages(
+    messages: list[dict],
+    *,
+    db_path: Path,
+    platform: str,
+    account_id: str = "main",
+    source_id: str,
+):
+    """Insert already-parsed messages while preserving upstream provenance."""
+    con = db.get_connection(db_path)
+    db.ensure_schema(con)
+
+    if not messages:
+        con.close()
+        return 0, 0
+
+    threads: dict[str, list[dict]] = {}
+    for msg in messages:
+        threads.setdefault(str(msg["thread_id"]), []).append(msg)
+
+    inserted = 0
+    duplicates = 0
+    for _tid, thread_messages in tqdm(threads.items(), desc="Importing", file=sys.stderr):
+        thread_messages.sort(key=lambda m: m["created_at"])
+        canonical_thread_id = _canonical_thread_id_for_messages(
+            thread_messages,
+            platform=platform,
+            account_id=account_id,
+        )
+
+        for msg in thread_messages:
+            ts_iso = iso_from_epoch(msg["created_at"])
+            if not ts_iso:
+                continue
+            message_id = _message_id_for_message(
+                msg,
+                platform=platform,
+                account_id=account_id,
+                canonical_thread_id=canonical_thread_id,
+            )
+            message_meta = _build_message_meta(msg["content"] or "")
+            was_inserted = db.insert_message(
+                con,
+                message_id,
+                canonical_thread_id,
+                platform,
+                account_id,
+                ts_iso,
+                msg["role"] or "",
+                msg["content"] or "",
+                msg.get("thread_title"),
+                source_id,
+                str(msg.get("thread_id") or "") or None,
+                str(msg.get("source_message_id") or "") or None,
+                message_meta,
+            )
+            if was_inserted:
+                inserted += 1
+            else:
+                duplicates += 1
+        con.commit()
+
+    con.close()
+    return inserted, duplicates
+
+
 def run(
     file_path: Path,
     db_path: Path,
@@ -69,66 +186,25 @@ def run(
     platform = platform or format_name
     source_id = source_id or f"import_{file_path.stem if not is_auto else format_name}"
 
-    con = db.get_connection(db_path)
-    db.ensure_schema(con)
-
     print(f"Parsing {format_name} export: {file_path}", file=sys.stderr)
     messages = list(parse(file_path, format_name))
 
     if not messages:
         print("No messages found in export.", file=sys.stderr)
-        con.close()
         return 0, 0
 
     thread_ids = set(m["thread_id"] for m in messages)
     print(f"Found {len(messages)} messages in {len(thread_ids)} threads.", file=sys.stderr)
 
-    # Group by thread
-    threads: dict[str, list[dict]] = {}
-    for msg in messages:
-        threads.setdefault(msg["thread_id"], []).append(msg)
-
-    inserted = 0
-    duplicates = 0
-
-    for _tid, thread_messages in tqdm(threads.items(), desc="Importing", file=sys.stderr):
-        thread_messages.sort(key=lambda m: m["created_at"])
-        first = thread_messages[0]
-        first_snip = (first["content"] or "")[:256]
-
-        canonical_thread_id = sha1("|".join([
-            platform,
-            account_id,
-            norm_text(first["thread_title"]),
-            str(round_epoch(first["created_at"]) or ""),
-            first["role"] or "",
-            norm_text(first_snip),
-        ]))
-
-        for msg in thread_messages:
-            ts_round = round_epoch(msg["created_at"]) or 0
-            message_id = sha1("|".join([
-                platform, account_id, canonical_thread_id, msg["role"] or "",
-                str(ts_round), norm_text(msg["content"] or ""),
-            ]))
-
-            ts_iso = iso_from_epoch(msg["created_at"])
-            if not ts_iso:
-                continue
-
-            was_inserted = db.insert_message(
-                con, message_id, canonical_thread_id, platform, account_id,
-                ts_iso, msg["role"] or "", msg["content"] or "",
-                msg["thread_title"], source_id,
-            )
-
-            if was_inserted:
-                inserted += 1
-            else:
-                duplicates += 1
-
-        con.commit()
-
+    inserted, duplicates = ingest_parsed_messages(
+        messages,
+        db_path=db_path,
+        platform=platform,
+        account_id=account_id,
+        source_id=source_id,
+    )
+    con = db.get_connection(db_path)
+    db.ensure_schema(con)
     total = db.message_count(con)
     con.close()
 
@@ -211,13 +287,17 @@ def run_source(
         print(f"Unknown source '{source_name}'. Run 'mychatarchive sources list'.", file=sys.stderr)
         return 0, 0
 
+    fmt = src.get("format")
+    account = src.get("account", "main")
+    source_type = src.get("type", "path")
+
+    if source_type == "live":
+        return run_live_source(source_name, db_path)
+
     path = Path(src["path"]).expanduser()
     if not path.exists():
         print(f"Source path does not exist: {path}", file=sys.stderr)
         return 0, 0
-
-    fmt = src.get("format")
-    account = src.get("account", "main")
 
     print(f"Importing from source '{source_name}' ({path})", file=sys.stderr)
 
@@ -234,6 +314,48 @@ def run_source(
             source_id=f"source_{source_name}",
         )
         return result or (0, 0)
+
+
+def run_live_source(source_name: str, db_path: Path):
+    """Import from a named live source using DB-first selector resolution."""
+    from mychatarchive.config import get_source
+
+    src = get_source(source_name)
+    if src is None:
+        print(f"Unknown source '{source_name}'. Run 'mychatarchive sources list'.", file=sys.stderr)
+        return 0, 0
+
+    provider = src.get("provider", "chatgpt")
+    selector = src.get("selector")
+    account = src.get("account", "main")
+    if not selector:
+        print(f"Live source '{source_name}' is missing a selector.", file=sys.stderr)
+        return 0, 0
+
+    resolved_selector, resolution_meta = choose_live_selector(db_path, selector)
+    print(
+        f"Importing live source '{source_name}' via {provider} "
+        f"(selector={selector!r}, resolved={resolved_selector!r})",
+        file=sys.stderr,
+    )
+
+    messages, live_meta = fetch_live_messages(provider, resolved_selector)
+    for message in messages:
+        if not message.get("thread_title") and src.get("title"):
+            message["thread_title"] = src["title"]
+
+    inserted, duplicates = ingest_parsed_messages(
+        messages,
+        db_path=db_path,
+        platform=provider,
+        account_id=account,
+        source_id=f"live_{source_name}",
+    )
+    print(
+        f"  Resolution: {resolution_meta.get('resolution')} -> {live_meta.get('provider_resolution')}",
+        file=sys.stderr,
+    )
+    return inserted, duplicates
 
 
 def run_auto_source(format_name: str, db_path: Path):

--- a/src/mychatarchive/itir.py
+++ b/src/mychatarchive/itir.py
@@ -1,0 +1,150 @@
+"""Required ITIR/SensibLaw enrichment for imported messages.
+
+MyChatArchive should not silently ingest messages without the shared-reducer
+normalization payload. Imports fail fast when the local ITIR surface is
+unavailable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from functools import lru_cache
+import importlib
+from pathlib import Path
+import sys
+from typing import Any
+
+from mychatarchive.config import get_itir_paths
+
+_SHARED_REDUCER_MODULE = "sensiblaw.interfaces.shared_reducer"
+
+
+class ITIREnrichment:
+    """Wrapper around the supported SensibLaw shared reducer surface."""
+
+    def __init__(self, root: Path, reducer_module):
+        self.root = root
+        self.reducer_module = reducer_module
+
+    def enrich_text(self, text: str) -> dict[str, Any] | None:
+        text = (text or "").strip()
+        if not text:
+            return None
+
+        reducer = self.reducer_module
+        payload: dict[str, Any] = {
+            "surface": _SHARED_REDUCER_MODULE,
+            "source_root": str(self.root),
+            "tokenizer_profile_receipt": reducer.get_canonical_tokenizer_profile_receipt(),
+            "token_spans": [
+                {"text": token, "start": start, "end": end}
+                for token, start, end in reducer.tokenize_canonical_with_spans(text)
+            ],
+            "lexeme_refs": reducer.collect_canonical_lexeme_refs(text),
+            "structure_occurrences": [
+                _to_plain_dict(occ)
+                for occ in reducer.collect_canonical_structure_occurrences(text)
+            ],
+        }
+
+        try:
+            payload["relational_bundle"] = reducer.collect_canonical_relational_bundle(text)
+        except Exception as exc:
+            payload["relational_bundle_error"] = type(exc).__name__
+
+        return payload
+
+
+def _to_plain_dict(value: Any) -> Any:
+    if is_dataclass(value):
+        return asdict(value)
+    if isinstance(value, dict):
+        return {key: _to_plain_dict(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_plain_dict(item) for item in value]
+    return value
+
+
+def _candidate_sys_paths(root: Path) -> list[Path]:
+    candidates: list[Path] = []
+    if root.name == "src":
+        candidates.append(root.parent)
+        candidates.append(root)
+    else:
+        candidates.append(root)
+        src_dir = root / "src"
+        if src_dir.is_dir():
+            candidates.append(src_dir)
+    return [path for path in candidates if path.exists()]
+
+
+def _import_shared_reducer(root: Path):
+    original_sys_path = list(sys.path)
+    for candidate in reversed(_candidate_sys_paths(root)):
+        candidate_str = str(candidate)
+        if candidate_str not in sys.path:
+            sys.path.insert(0, candidate_str)
+    try:
+        return importlib.import_module(_SHARED_REDUCER_MODULE)
+    finally:
+        sys.path[:] = original_sys_path
+
+
+def _normalize_candidate_path(path: Path) -> Path:
+    path = path.expanduser().resolve()
+    if path.name == "shared_reducer.py":
+        return path.parent.parent.parent
+    if path.name == "interfaces":
+        return path.parent.parent
+    if path.name == "sensiblaw":
+        return path.parent
+    return path
+
+
+def _iter_candidate_roots() -> tuple[Path, ...]:
+    configured = tuple(_normalize_candidate_path(path) for path in get_itir_paths())
+    if configured:
+        return configured
+
+    repo_root = Path(__file__).resolve().parents[2]
+    defaults = (
+        repo_root.parent / "ITIR-suite" / "SensibLaw",
+        Path.home() / "Documents" / "code" / "ITIR-suite" / "SensibLaw",
+    )
+    return tuple(path for path in defaults if path.exists())
+
+
+@lru_cache(maxsize=8)
+def _load_enrichment(root_value: str) -> ITIREnrichment | None:
+    root = Path(root_value)
+    if not root.exists():
+        return None
+    try:
+        reducer_module = _import_shared_reducer(root)
+    except Exception:
+        return None
+    return ITIREnrichment(root=root, reducer_module=reducer_module)
+
+
+def get_itir_enrichment() -> ITIREnrichment | None:
+    for root in _iter_candidate_roots():
+        enrichment = _load_enrichment(str(root))
+        if enrichment is not None:
+            return enrichment
+    return None
+
+
+def enrich_text(text: str) -> dict[str, Any] | None:
+    text = (text or "").strip()
+    if not text:
+        return None
+
+    enrichment = get_itir_enrichment()
+    if enrichment is None:
+        roots = ", ".join(str(path) for path in _iter_candidate_roots()) or "<none found>"
+        raise RuntimeError(
+            "Required ITIR shared reducer is unavailable. "
+            f"Checked roots: {roots}. Configure config.itir.paths or "
+            "MYCHATARCHIVE_ITIR_PATHS."
+        )
+    return enrichment.enrich_text(text)

--- a/src/mychatarchive/live.py
+++ b/src/mychatarchive/live.py
@@ -1,0 +1,364 @@
+"""Live source resolution and ChatGPT provider fetch helpers."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import re
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from mychatarchive.config import get_re_gpt_roots
+
+_ONLINE_THREAD_ID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+_ONLINE_THREAD_ID_FROM_URL_RE = re.compile(
+    r"/c/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+)
+
+
+@dataclass
+class DbResolution:
+    match_type: str
+    canonical_thread_id: str
+    source_thread_id: str | None
+    title: str
+    matched_thread_count: int
+    latest_ts: str | None
+
+
+def looks_like_online_thread_id(selector: str) -> bool:
+    return bool(_ONLINE_THREAD_ID_RE.fullmatch(selector.strip()))
+
+
+def looks_like_canonical_thread_id(selector: str) -> bool:
+    return bool(re.fullmatch(r"[0-9a-f]{40}", selector.strip().lower()))
+
+
+def extract_online_thread_id_from_url(selector: str) -> str | None:
+    match = _ONLINE_THREAD_ID_FROM_URL_RE.search(selector)
+    if match:
+        return match.group(1)
+    return None
+
+
+def normalize_live_selector(selector: str) -> str:
+    candidate = (selector or "").strip()
+    online_id = extract_online_thread_id_from_url(candidate)
+    if online_id:
+        return online_id
+    return candidate
+
+
+def _fts_query(selector: str) -> str | None:
+    tokens = re.findall(r"[A-Za-z0-9_]{2,}", selector.lower())
+    if not tokens:
+        return None
+    seen: set[str] = set()
+    uniq: list[str] = []
+    for token in tokens:
+        if token in seen:
+            continue
+        seen.add(token)
+        uniq.append(token)
+    if not uniq:
+        return None
+    return " OR ".join(f"{token}*" for token in uniq)
+
+
+def resolve_selector_from_db(db_path: Path, selector: str) -> DbResolution | None:
+    if not db_path.exists():
+        return None
+
+    con = sqlite3.connect(str(db_path))
+    try:
+        cur = con.cursor()
+        cols = {
+            row[1]
+            for row in cur.execute("PRAGMA table_info(messages)").fetchall()
+        }
+        if not cols:
+            return None
+        normalized = normalize_live_selector(selector)
+
+        if "source_thread_id" in cols:
+            row = cur.execute(
+                """
+                SELECT canonical_thread_id, source_thread_id, COALESCE(NULLIF(title, ''), '(no title)'), MAX(ts)
+                FROM messages
+                WHERE LOWER(source_thread_id) = LOWER(?)
+                GROUP BY canonical_thread_id, source_thread_id, title
+                ORDER BY MAX(ts) DESC
+                LIMIT 1
+                """,
+                (normalized,),
+            ).fetchone()
+            if row:
+                return DbResolution("source_thread_id_exact", row[0], row[1], row[2], 1, row[3])
+
+        if looks_like_canonical_thread_id(normalized):
+            row = cur.execute(
+                """
+                SELECT canonical_thread_id, source_thread_id, COALESCE(NULLIF(title, ''), '(no title)'), MAX(ts)
+                FROM messages
+                WHERE LOWER(canonical_thread_id) = LOWER(?)
+                GROUP BY canonical_thread_id, source_thread_id, title
+                ORDER BY MAX(ts) DESC
+                LIMIT 1
+                """,
+                (normalized,),
+            ).fetchone()
+            if row:
+                return DbResolution("canonical_thread_id_exact", row[0], row[1], row[2], 1, row[3])
+
+        row = cur.execute(
+            """
+            SELECT canonical_thread_id, source_thread_id, COALESCE(NULLIF(title, ''), '(no title)'), MAX(ts)
+            FROM messages
+            WHERE LOWER(title) = LOWER(?)
+            GROUP BY canonical_thread_id, source_thread_id, title
+            ORDER BY MAX(ts) DESC
+            LIMIT 1
+            """,
+            (normalized,),
+        ).fetchone()
+        if row:
+            matched = cur.execute(
+                "SELECT COUNT(DISTINCT canonical_thread_id) FROM messages WHERE LOWER(title) = LOWER(?)",
+                (normalized,),
+            ).fetchone()[0]
+            return DbResolution("title_exact", row[0], row[1], row[2], int(matched or 0), row[3])
+
+        if len(normalized) >= 3:
+            like = f"%{normalized.lower()}%"
+            row = cur.execute(
+                """
+                SELECT canonical_thread_id, source_thread_id, COALESCE(NULLIF(title, ''), '(no title)'), MAX(ts)
+                FROM messages
+                WHERE LOWER(title) LIKE ?
+                GROUP BY canonical_thread_id, source_thread_id, title
+                ORDER BY MAX(ts) DESC
+                LIMIT 1
+                """,
+                (like,),
+            ).fetchone()
+            if row:
+                matched = cur.execute(
+                    "SELECT COUNT(DISTINCT canonical_thread_id) FROM messages WHERE LOWER(title) LIKE ?",
+                    (like,),
+                ).fetchone()[0]
+                return DbResolution("title_contains", row[0], row[1], row[2], int(matched or 0), row[3])
+
+        if not looks_like_online_thread_id(normalized):
+            fts_query = _fts_query(normalized)
+            table_names = {
+                row[0]
+                for row in cur.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('messages_fts', 'messages_fts_docids')"
+                ).fetchall()
+            }
+            if fts_query and {"messages_fts", "messages_fts_docids"} <= table_names:
+                row = cur.execute(
+                    """
+                    SELECT m.canonical_thread_id, m.source_thread_id,
+                           COALESCE(NULLIF(m.title, ''), '(no title)') AS title,
+                           MAX(m.ts) AS latest_ts,
+                           COUNT(*) AS hit_count
+                    FROM messages_fts f
+                    JOIN messages_fts_docids d ON f.rowid = d.rowid
+                    JOIN messages m ON m.message_id = d.message_id
+                    WHERE messages_fts MATCH ?
+                    GROUP BY m.canonical_thread_id, m.source_thread_id, title
+                    ORDER BY hit_count DESC, latest_ts DESC
+                    LIMIT 1
+                    """,
+                    (fts_query,),
+                ).fetchone()
+                if row:
+                    matched = cur.execute(
+                        """
+                        SELECT COUNT(*) FROM (
+                            SELECT DISTINCT m.canonical_thread_id
+                            FROM messages_fts f
+                            JOIN messages_fts_docids d ON f.rowid = d.rowid
+                            JOIN messages m ON m.message_id = d.message_id
+                            WHERE messages_fts MATCH ?
+                        )
+                        """,
+                        (fts_query,),
+                    ).fetchone()[0]
+                    return DbResolution("fts_candidate", row[0], row[1], row[2], int(matched or 0), row[3])
+        return None
+    finally:
+        con.close()
+
+
+def choose_live_selector(db_path: Path, selector: str) -> tuple[str, dict[str, Any]]:
+    normalized = normalize_live_selector(selector)
+    resolution = resolve_selector_from_db(db_path, normalized)
+    if looks_like_online_thread_id(normalized):
+        return normalized, {"resolution": "selector_online_thread_id"}
+    if resolution and resolution.source_thread_id and resolution.matched_thread_count == 1:
+        return resolution.source_thread_id, {
+            "resolution": resolution.match_type,
+            "canonical_thread_id": resolution.canonical_thread_id,
+            "title": resolution.title,
+        }
+    return normalized, {
+        "resolution": resolution.match_type if resolution else "provider_fallback",
+        "canonical_thread_id": resolution.canonical_thread_id if resolution else None,
+        "title": resolution.title if resolution else None,
+        "matched_thread_count": resolution.matched_thread_count if resolution else 0,
+    }
+
+
+def load_session_token() -> str | None:
+    env_token = os.environ.get("CHATGPT_SESSION_TOKEN", "").strip()
+    if env_token:
+        return env_token
+    session_file = Path.home() / ".chatgpt_session"
+    if session_file.exists():
+        lines = session_file.read_text(encoding="utf-8", errors="ignore").splitlines()
+        if lines and lines[0].strip():
+            return lines[0].strip()
+    return None
+
+
+def resolve_live_provider_root() -> Path:
+    for root in get_re_gpt_roots():
+        if (root / "re_gpt").is_dir():
+            return root
+    raise RuntimeError(
+        "No reverse-engineered-chatgpt checkout found. Configure live.re_gpt_paths "
+        "or MYCHATARCHIVE_RE_GPT_PATHS."
+    )
+
+
+def _load_re_gpt_modules(root: Path):
+    original_sys_path = list(sys.path)
+    try:
+        root_str = str(root)
+        if root_str not in sys.path:
+            sys.path.insert(0, root_str)
+        sync = importlib.import_module("re_gpt.sync_chatgpt")
+        return sync.SyncChatGPT
+    finally:
+        sys.path[:] = original_sys_path
+
+
+def _resolve_chatgpt_selector(chatgpt, selector: str) -> tuple[str, str | None, str]:
+    normalized = normalize_live_selector(selector)
+    if looks_like_online_thread_id(normalized):
+        return normalized, None, "online_thread_id"
+
+    target = normalized.lower()
+    contains_match: tuple[str, str | None, str] | None = None
+    offset = 0
+    limit = 100
+    while True:
+        page = chatgpt.list_conversations_page(offset=offset, limit=limit)
+        items = page.get("items", []) if isinstance(page, dict) else []
+        if not items:
+            break
+        for item in items:
+            title = str(item.get("title") or "").strip()
+            conversation_id = str(item.get("id") or "").strip()
+            if not title or not conversation_id:
+                continue
+            lowered = title.lower()
+            if lowered == target:
+                return conversation_id, title, "title_exact"
+            if target in lowered and contains_match is None:
+                contains_match = (conversation_id, title, "title_contains")
+        offset += len(items)
+        if len(items) < limit:
+            break
+    if contains_match:
+        return contains_match
+    raise RuntimeError(f"Unable to resolve live selector: {selector}")
+
+
+def _convert_chat_payload(chat: dict[str, Any]) -> list[dict[str, Any]]:
+    mapping = chat.get("mapping")
+    title = str(chat.get("title") or "")
+    conversation_id = str(chat.get("conversation_id") or chat.get("id") or "").strip()
+    parsed: list[dict[str, Any]] = []
+    if not isinstance(mapping, dict):
+        return parsed
+
+    for node_id, node in mapping.items():
+        if not isinstance(node, dict):
+            continue
+        message = node.get("message")
+        if not isinstance(message, dict):
+            continue
+        author_info = message.get("author") or {}
+        role = str(author_info.get("role") or "")
+        content_info = message.get("content") or {}
+        raw_parts = content_info.get("parts") or []
+        parts: list[str] = []
+        if isinstance(raw_parts, list):
+            for part in raw_parts:
+                if isinstance(part, str) and part.strip():
+                    parts.append(part.strip())
+                elif isinstance(part, dict):
+                    for key in ("text", "content", "title"):
+                        value = part.get(key)
+                        if value:
+                            parts.append(str(value).strip())
+                            break
+        if not parts:
+            continue
+        created_at = message.get("create_time") or message.get("update_time") or 0
+        try:
+            created_at = float(created_at)
+        except (TypeError, ValueError):
+            created_at = 0.0
+        parsed.append(
+            {
+                "thread_id": conversation_id,
+                "thread_title": title,
+                "role": role,
+                "content": "\n".join(parts),
+                "created_at": created_at,
+                "source_message_id": str(message.get("id") or node_id or ""),
+            }
+        )
+
+    parsed.sort(key=lambda item: item["created_at"])
+    for idx, message in enumerate(parsed):
+        if not message.get("source_message_id"):
+            message["source_message_id"] = f"idx:{idx}"
+    return parsed
+
+
+def fetch_live_messages(provider: str, selector: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    provider_name = (provider or "chatgpt").strip().lower()
+    if provider_name != "chatgpt":
+        raise RuntimeError(f"Unsupported live provider: {provider}")
+
+    root = resolve_live_provider_root()
+    session_token = load_session_token()
+    if not session_token:
+        raise RuntimeError(
+            "No ChatGPT session token found. Set CHATGPT_SESSION_TOKEN or create ~/.chatgpt_session."
+        )
+
+    SyncChatGPT = _load_re_gpt_modules(root)
+    with SyncChatGPT(session_token=session_token) as chatgpt:
+        conversation_id, title, provider_resolution = _resolve_chatgpt_selector(chatgpt, selector)
+        chat = chatgpt.fetch_conversation(conversation_id)
+    messages = _convert_chat_payload(chat)
+    return messages, {
+        "provider": provider_name,
+        "provider_root": str(root),
+        "selector": selector,
+        "resolved_selector": conversation_id,
+        "provider_resolution": provider_resolution,
+        "title": title or chat.get("title"),
+        "fetched_at": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
+    }

--- a/src/mychatarchive/parsers/chatgpt.py
+++ b/src/mychatarchive/parsers/chatgpt.py
@@ -57,6 +57,7 @@ def _parse_conversation(convo: dict) -> Iterator[dict]:
             "role": role,
             "content": content,
             "created_at": float(ts),
+            "source_message_id": m.get("id") or node_id,
         })
 
     messages.sort(key=lambda x: x["created_at"])

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -30,6 +30,13 @@ def test_schema_creation(test_db):
     assert "messages" in tables
     assert "chunks" in tables
     assert "thoughts" in tables
+    cols = {
+        row[1]
+        for row in con.execute("PRAGMA table_info(messages)").fetchall()
+    }
+    assert "meta" in cols
+    assert "source_thread_id" in cols
+    assert "source_message_id" in cols
 
 
 def test_insert_message(test_db):
@@ -37,9 +44,19 @@ def test_insert_message(test_db):
     result = db.insert_message(
         con, "msg1", "thread1", "chatgpt", "main",
         "2026-01-01T00:00:00Z", "user", "Hello world", "Test", "src1",
+        "conv-123", "msg-upstream-1",
+        {"itir": {"tokenizer_profile_receipt": {"profile_id": "abc"}}},
     )
     assert result is True
     assert db.message_count(con) == 1
+    stored = con.execute(
+        "SELECT source_thread_id, source_message_id, meta FROM messages WHERE message_id = ?",
+        ("msg1",),
+    ).fetchone()
+    assert stored[0] == "conv-123"
+    assert stored[1] == "msg-upstream-1"
+    assert stored[2] is not None
+    assert "profile_id" in stored[2]
 
     dupe = db.insert_message(
         con, "msg1", "thread1", "chatgpt", "main",

--- a/tests/test_itir.py
+++ b/tests/test_itir.py
@@ -1,0 +1,77 @@
+"""Tests for required ITIR enrichment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mychatarchive import itir
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_enrich_text_uses_local_shared_reducer(monkeypatch, tmp_path):
+    fake_root = tmp_path / "SensibLaw"
+    _write(
+        fake_root / "src" / "sensiblaw" / "__init__.py",
+        "",
+    )
+    _write(
+        fake_root / "src" / "sensiblaw" / "interfaces" / "__init__.py",
+        "",
+    )
+    _write(
+        fake_root / "src" / "sensiblaw" / "interfaces" / "shared_reducer.py",
+        """
+from dataclasses import dataclass
+
+def get_canonical_tokenizer_profile_receipt():
+    return {"profile_id": "fake", "canonical_mode": "deterministic_legal"}
+
+def tokenize_canonical_with_spans(text):
+    return [("hello", 0, 5), ("world", 6, 11)]
+
+def collect_canonical_lexeme_refs(text):
+    return [{"occurrence_id": "abc", "kind": "word", "span_start": 0, "span_end": 5}]
+
+@dataclass(frozen=True)
+class _Structure:
+    text: str
+    norm_text: str
+    kind: str
+    start_char: int
+    end_char: int
+    flags: int = 0
+
+def collect_canonical_structure_occurrences(text):
+    return [_Structure("hello", "hello", "word_ref", 0, 5, 0)]
+
+def collect_canonical_relational_bundle(text):
+    return {"version": "relational_bundle_v1", "canonical_text": text, "atoms": [], "relations": []}
+""",
+    )
+
+    itir._load_enrichment.cache_clear()
+    monkeypatch.setenv("MYCHATARCHIVE_ITIR_PATHS", str(fake_root))
+
+    payload = itir.enrich_text("hello world")
+
+    assert payload is not None
+    assert payload["surface"] == "sensiblaw.interfaces.shared_reducer"
+    assert payload["source_root"] == str(fake_root.resolve())
+    assert payload["token_spans"][0]["text"] == "hello"
+    assert payload["lexeme_refs"][0]["occurrence_id"] == "abc"
+    assert payload["structure_occurrences"][0]["kind"] == "word_ref"
+    assert payload["relational_bundle"]["version"] == "relational_bundle_v1"
+
+
+def test_enrich_text_raises_when_missing(monkeypatch, tmp_path):
+    itir._load_enrichment.cache_clear()
+    monkeypatch.setattr("mychatarchive.itir.get_itir_paths", lambda: [tmp_path / "missing"])
+    monkeypatch.delenv("MYCHATARCHIVE_ITIR_PATHS", raising=False)
+    with pytest.raises(RuntimeError):
+        itir.enrich_text("hello world")


### PR DESCRIPTION
## Summary
- add required local ITIR shared-reducer enrichment on ingest with configurable local path resolution
- add provenance-aware ingest plus DB-first live ChatGPT selector resolution with provider fallback
- add NotebookLM pack/ingest CLI surfaces and preserve upstream ChatGPT message IDs
- tighten the SQLite ingest hot path by using insert cursor rowids for FTS doc mapping and ingest-friendly pragmas

## Details
This keeps the integration local-first: it consumes external ITIR and reverse-engineered-chatgpt checkouts via configured/local paths, but does not vendor or modify either external repo.

The live-source path is DB-first:
- exact `source_thread_id`
- exact canonical thread id
- exact/contains title matches
- FTS candidate ranking
- provider fallback only if the archive cannot disambiguate the selector

The ingest path now stores `source_thread_id`, `source_message_id`, and additive ITIR metadata in `meta`, and exports those provenance fields.

## Verification
- `python -m py_compile src/mychatarchive/config.py src/mychatarchive/itir.py src/mychatarchive/live.py src/mychatarchive/ingest.py src/mychatarchive/cli.py src/mychatarchive/db.py src/mychatarchive/backends/storage/sqlite.py src/mychatarchive/parsers/chatgpt.py tests/test_db.py tests/test_itir.py`
- `PYTHONPATH=src pytest -q tests/test_itir.py`
- `PYTHONPATH=src python -m mychatarchive --help`
- `PYTHONPATH=src python -m mychatarchive notebooklm --help`
- `PYTHONPATH=src python -m mychatarchive sources --help`

## Known limits
- `PYTHONPATH=src pytest -q tests/test_db.py` currently fails in this environment because `sqlite_vec` is not installed
- I did not exercise a real live ChatGPT pull in this environment because that requires a valid session token and local provider runtime
