### PR TITLE
Add ITIR enrichment and canonical archive vector bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,36 @@ mychatarchive serve
 
 The pipeline is incremental. Re-run `sync` any time -- SHA1 dedup means it's always safe. New messages get embedded on the next `embed` run without `--force`.
 
+### Required ITIR Enrichment
+
+MyChatArchive now expects a local `SensibLaw` checkout and attaches normalized
+token, structure, and relation metadata to every imported message. Ingest fails
+fast if that local shared-reducer surface is unavailable.
+
+Point the importer at one or more local checkouts in priority order:
+
+```bash
+export MYCHATARCHIVE_ITIR_PATHS="/path/to/SensibLaw:/path/to/fallback/SensibLaw"
+mychatarchive sync
+```
+
+You can also set the same paths in `~/.mychatarchive/config.json`:
+
+```json
+{
+  "itir": {
+    "paths": [
+      "/path/to/newer/SensibLaw",
+      "/path/to/fallback/SensibLaw"
+    ]
+  }
+}
+```
+
+If you keep multiple local checkouts, list the preferred one first. Existing
+canonical thread/message IDs remain stable; the extra metadata is additive and
+stored in the message `meta` field.
+
 ---
 
 ## Sync
@@ -171,9 +201,34 @@ mychatarchive sync --embed   # sync + generate embeddings in one shot
 
 1. **Auto-discovery** -- Claude Code sessions (`~/.claude/projects/`) and Cursor conversations from local databases. Enabled by default, toggleable in `init`.
 2. **Drop folder** -- anything in `~/.mychatarchive/imports/`. Drop your ChatGPT, Claude, or Grok export JSON here; format is auto-detected. Subdirectories scanned recursively.
-3. **Named sources** -- custom paths or NAS shares you've configured with `mychatarchive sources add`.
+3. **Named sources** -- path sources via `mychatarchive sources add`, plus live ChatGPT-backed sources via `mychatarchive sources add-live`.
 
 All three deduplicate into the same archive via SHA1 hashing.
+
+### Live Sources
+
+Configure a live source when you want `sync` or `import --from` to pull a
+conversation directly from ChatGPT using a DB-first selector policy and a live
+fallback only when the archive cannot disambiguate the selector.
+
+```bash
+mychatarchive sources add-live project-chat "Project chat"
+mychatarchive sources add-live product-thread "https://chatgpt.com/c/1234..." --title "Product thread"
+mychatarchive import --from project-chat
+```
+
+Live sources preserve upstream `source_thread_id` and `source_message_id`
+provenance in the archive.
+
+### NotebookLM
+
+The sibling `../notebooklm-pack` workflow is exposed directly:
+
+```bash
+mychatarchive notebooklm pack ../_repo_readmes /tmp/mca-pack
+mychatarchive notebooklm ingest --manifest /tmp/mca-pack/manifest.json --notebook-url https://notebooklm.google.com/notebook/NOTEBOOK_ID --output /tmp/mca-ingest.json
+mychatarchive notebooklm pack-ingest ../_repo_readmes /tmp/mca-pack --notebook-title "MyChatArchive Context" --output /tmp/mca-ingest.json
+```
 
 > **Note:** Auto-discovery covers Claude Code (the terminal agent) and Cursor. Claude web, mobile, and desktop app conversations require a manual export from Anthropic's settings -- drop the file in your imports folder and run `sync`.
 
@@ -352,9 +407,13 @@ Named sources (NAS, custom paths)     --+              |
 | `mychatarchive import <file\|dir>` | Import a single file or directory |
 | `mychatarchive import --from <name>` | Import from a named source |
 | `mychatarchive sources add <name> <path>` | Add a named import source |
+| `mychatarchive sources add-live <name> <selector>` | Add a named live source |
 | `mychatarchive sources list` | Show all sources (auto + drop + named) |
 | `mychatarchive sources remove <name>` | Remove a source |
 | `mychatarchive sources rename <old> <new>` | Rename a source |
+| `mychatarchive notebooklm pack ...` | Run sibling `notebooklm-pack` |
+| `mychatarchive notebooklm ingest ...` | Upload a `manifest.json` to NotebookLM |
+| `mychatarchive notebooklm pack-ingest ...` | Pack then upload in one command |
 | `mychatarchive summarize` | Generate LLM thread summaries (needs API key) |
 | `mychatarchive groups list` | List all thread groups |
 | `mychatarchive groups create <name>` | Create a thread group |

--- a/README.md
+++ b/README.md
@@ -158,11 +158,13 @@ mychatarchive serve
 
 The pipeline is incremental. Re-run `sync` any time -- SHA1 dedup means it's always safe. New messages get embedded on the next `embed` run without `--force`.
 
-### Required ITIR Enrichment
+### Current ITIR Enrichment
 
-MyChatArchive now expects a local `SensibLaw` checkout and attaches normalized
-token, structure, and relation metadata to every imported message. Ingest fails
-fast if that local shared-reducer surface is unavailable.
+MyChatArchive currently expects a local `SensibLaw` checkout and attaches
+shared-reducer metadata to every imported message. This is real ITIR-backed
+enrichment, but it is not yet the full ITIR archive/governance model. Today the
+ingest path stores token, structure, and relation metadata in the message
+`meta` field and fails fast if that local shared-reducer surface is unavailable.
 
 Point the importer at one or more local checkouts in priority order:
 
@@ -187,6 +189,56 @@ You can also set the same paths in `~/.mychatarchive/config.json`:
 If you keep multiple local checkouts, list the preferred one first. Existing
 canonical thread/message IDs remain stable; the extra metadata is additive and
 stored in the message `meta` field.
+
+For the deeper transition plan from shared-reducer enrichment to full
+archive-truth, provenance, predicate, and residual-aware integration, see
+[docs/itir-native-transition.md](docs/itir-native-transition.md).
+
+### Canonical Archive Vector Alignment
+
+MyChatArchive already has local vector search over its own SQLite archive:
+
+```bash
+mychatarchive sync --embed
+mychatarchive embed
+mychatarchive search "database architecture decisions"
+mychatarchive search "exact phrase or identifier" --mode keyword
+mychatarchive serve
+```
+
+The ITIR/robust-context-fetch alignment is narrower than "add vectors":
+vectors should attach to canonical archive rows, not generated Markdown
+sidecars or a parallel truth store. The bridge, agent wrapper scripts,
+semantic result provenance contract, hybrid merge path, and resolver opt-in
+flags now exist; `mychatarchive` semantic search remains a candidate-discovery
+surface until bridge-derived embeddings have been generated and validated in a
+live MCA archive.
+
+Agent scripts for that bridge are:
+
+- `scripts/mca_sync_from_canonical_archive.py`
+- `scripts/mca_embed_missing.py`
+- `scripts/mca_semantic_search.py`
+- `scripts/mca_hybrid_search.py`
+- `scripts/mca_resolve_result.py`
+
+Provenance fields for every vector or hybrid result:
+
+- source database path
+- canonical thread ID
+- source thread ID
+- source message ID or chunk ID
+- title
+- role
+- timestamp or timestamp range
+- score and/or distance
+- matched excerpt
+
+Implementation status: the canonical archive bridge, agent scripts, semantic
+provenance contract, hybrid merge contract, and robust-context-fetch resolver
+flags have focused tests and missing-DB smoke coverage. Live embedding
+generation and happy-path semantic/hybrid retrieval still require a populated
+MCA archive DB.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,6 +52,101 @@ A personal AI memory system that compounds from daily usage. Start with searchab
 
 ---
 
+## Phase 2.5: ITIR-Native Archive Transition
+
+**Goal:** Move from shared-reducer enrichment in `messages.meta` to a full
+archive-truth + provenance + predicate/residual-aware architecture.
+
+### Archive Truth
+- [ ] Add `source_path`, `source_bucket`, and `provenance_json` to `messages`
+- [ ] Add `message_blocks`
+- [ ] Add `provenance_refs`
+- [ ] Preserve backward compatibility with existing SQLite archives
+
+### Ingest Spine Alignment
+- [ ] Route `import` / `sync` through the archive ingest spine instead of
+      maintaining a diverging parser/provenance layer
+- [ ] Preserve existing source workflows: named sources, auto-discovery, live sources
+- [ ] Reuse normalized batch sidecars (`itir.normalized.artifact.v1`)
+
+### ITIR Projections
+- [ ] Promote predicate-level projections out of `messages.meta["itir"]`
+- [ ] Persist bounded predicate refs, roles, polarity/modality, and span refs
+- [ ] Add rebuildable predicate index surfaces
+
+### Residual-Aware Retrieval
+- [ ] Use predicate overlap/residuals in retrieval ranking and context assembly
+- [ ] Surface contradictions, unresolved pressure, and follow obligations
+- [ ] Make explanations provenance- and governance-aware
+
+---
+
+## Phase 2.6: Canonical Archive Vector Alignment
+
+**Goal:** Align MyChatArchive's existing local vector search with the canonical
+AI conversation archive used by robust-context-fetch and ITIR-suite agents.
+
+This is not a replacement for the current MCA search pipeline. It is a bridge
+contract: canonical archive rows remain the source of truth; MCA vectors become
+an optional retrieval index over deterministic message/chunk records.
+
+### Current State
+- [x] MCA local embeddings via sentence-transformers
+- [x] MCA vector storage through sqlite-vec
+- [x] MCA FTS5 keyword search
+- [x] MCA semantic CLI search
+- [x] MCA MCP tools for semantic context retrieval
+- [x] Canonical `~/chat_archive.sqlite` to MCA bridge
+- [x] Agent-safe bridge/search scripts
+- [x] Hybrid FTS + vector retrieval over shared canonical IDs
+- [x] robust-context-fetch semantic/hybrid resolver flags
+
+### Six-Lane Integration Plan
+
+1. **Canonical Schema Bridge**
+   - [x] Import canonical archive message rows into MCA without creating a
+         second source of truth
+   - [x] Preserve `canonical_thread_id`, `source_thread_id`,
+         `source_message_id`, role, text, title, timestamp, platform, account,
+         and provenance
+   - [x] Make re-runs idempotent
+
+2. **Agent Script Wrappers**
+   - [x] Add `scripts/mca_sync_from_canonical_archive.py`
+   - [x] Add `scripts/mca_embed_missing.py`
+   - [x] Add `scripts/mca_semantic_search.py`
+   - [x] Add `scripts/mca_hybrid_search.py`
+   - [x] Add `scripts/mca_resolve_result.py`
+   - [x] Use stable JSON output and explicit DB arguments
+
+3. **Semantic Search Contract**
+   - [x] Every semantic result includes canonical IDs, chunk/message IDs, title,
+         timestamps, source DB, score/distance, and excerpt
+   - [x] No semantic result is agent-facing without provenance
+
+4. **Hybrid Retrieval**
+   - [x] Merge FTS candidates and semantic candidates by canonical IDs
+   - [x] Weight exact identifiers, names, dates, and quoted phrases above vague
+         embedding matches
+   - [x] Expose `mychatarchive search <query> --mode hybrid`
+
+5. **Resolver Integration**
+   - [x] Add optional `--semantic`, `--hybrid`, `--mca-db`, and `--mca-limit`
+         to the robust-context-fetch resolver after the bridge exists
+   - [x] Keep resolver behavior DB-first and lexical unless semantic/hybrid is
+         explicitly requested
+
+6. **Docs and Validation**
+   - [x] Update README, roadmap, and skill examples after implementation lands
+   - [x] Keep implemented behavior separate from target-contract text
+   - [x] Validate bridge import idempotency
+   - [ ] Validate embeddings for bridge-derived chunks
+   - [x] Validate semantic results include canonical provenance
+   - [x] Validate hybrid search returns exact and semantic matches
+   - [x] Validate resolver semantic/hybrid JSON output
+
+---
+
 ## Phase 3: Analysis Engine
 
 **Goal:** Run deep research prompts against your own archive. Not a chat -- a batch analysis tool.

--- a/docs/itir-native-transition.md
+++ b/docs/itir-native-transition.md
@@ -1,0 +1,329 @@
+# MyChatArchive ITIR-Native Transition Audit
+
+## Purpose
+
+This document audits the current `mychatarchive` ingest architecture against the
+newer archive/provenance spine already proven in `chat-export-structurer`, then
+lays out the migration path to make `mychatarchive` properly ITIR-native rather
+than merely ITIR-enriched.
+
+The intended end state is:
+
+- `chat-export-structurer` remains the source artifact + provenance ingest spine.
+- `mychatarchive` becomes the product/query layer above that spine.
+- SensibLaw/ITIR predicate and residual machinery becomes first-class retrieval
+  infrastructure rather than JSON stuffed into `messages.meta`.
+
+## Current Audit
+
+### What `mychatarchive` already does well
+
+- Stable archive identity:
+  - `source_thread_id` and `source_message_id` are preserved and preferred when
+    present.
+  - Fallback dedupe is deterministic and thread-aware.
+- Operational ingest surfaces already exist:
+  - direct file import
+  - directory import
+  - named path sources
+  - auto-discovery sources
+  - live ChatGPT-backed sources with DB-first selector resolution
+- Product surfaces already exist:
+  - FTS search
+  - vector embeddings
+  - MCP server
+  - thread summaries
+  - NotebookLM helpers
+- Shared-reducer integration is already wired and enforced:
+  - token spans
+  - lexeme refs
+  - structure occurrences
+  - relational bundle
+
+### What `mychatarchive` does not yet implement
+
+The current storage layer does not yet expose archive-truth or governance
+surfaces that are already present in the newer ingest spine:
+
+- no `source_path`
+- no `source_bucket`
+- no `provenance_json` on `messages`
+- no `message_blocks`
+- no `provenance_refs`
+- no `itir.normalized.artifact.v1` batch sidecars
+- no replay-oriented provenance pointers
+- no first-class authority/lineage/follow/unresolved-pressure surfaces
+
+The current ITIR integration is limited to per-message shared-reducer payloads
+written into `messages.meta["itir"]`. That is useful, but it is not the same as
+full ITIR archive or residual-lattice integration.
+
+### Deeper SensibLaw/ITIR machinery currently unused
+
+The local SensibLaw surface already exposes materially richer structure than
+`mychatarchive` uses today, including:
+
+- `PredicatePNF`
+- `PredicateAtom`
+- `PredicateIndex`
+- `build_predicate_index`
+- `build_predicate_ref_map`
+- `collect_candidate_predicate_refs`
+- `collect_candidate_residuals`
+- `compute_indexed_residual`
+- `compute_residual`
+- `join_residual`
+
+This means the gap is not lack of upstream machinery. The gap is that
+`mychatarchive` has not yet promoted these outputs into durable retrieval and
+governance surfaces.
+
+## Current Ingest Machinery That Must Be Preserved
+
+The migration must preserve the existing operator workflows:
+
+- `mychatarchive import <file-or-dir>`
+- `mychatarchive import --from <source>`
+- `mychatarchive sync`
+- named file/directory sources
+- live sources
+- auto-discovery sources
+- incremental re-runs without duplicate explosion
+
+The right migration is therefore not a rewrite of the CLI contract. It is a
+replacement of the ingest/storage substrate under those entrypoints.
+
+## Architectural Read
+
+### Correct layer split
+
+- `chat-export-structurer`
+  - source parsing
+  - replayable provenance
+  - batch sidecars
+  - archive truth
+  - parser-specific normalization
+- `mychatarchive`
+  - retrieval
+  - ranking
+  - embeddings
+  - MCP/query APIs
+  - summaries
+  - ITIR predicate/residual-aware context assembly
+
+`mychatarchive` should not re-implement every parser or provenance decision
+itself. It should consume the normalized archive truth surface.
+
+## Transition Roadmap
+
+## Stage 0: Honest Contract and Compatibility Envelope
+
+### Goals
+
+- Stop overstating current ITIR depth.
+- Define the compatibility boundary for existing users and DBs.
+
+### Deliverables
+
+- README language that describes current integration as shared-reducer
+  enrichment, not full ITIR-native architecture.
+- explicit migration note that existing CLI commands remain stable
+- transition doc and milestone plan
+
+### Success criteria
+
+- user-facing docs no longer imply that `messages.meta["itir"]` is the end state
+- migration work can proceed without changing day-to-day commands first
+
+## Stage 1: Archive-Truth Parity in `mychatarchive`
+
+### Goals
+
+Bring `mychatarchive`’s SQLite schema and ingest write path up to parity with
+the archive-truth surfaces already in the ingest spine.
+
+### Required schema additions
+
+- extend `messages` with:
+  - `source_path`
+  - `source_bucket`
+  - `provenance_json`
+- add `message_blocks`
+- add `provenance_refs`
+
+### Required ingest changes
+
+- accept parser outputs with:
+  - `content_blocks`
+  - `provenance_refs`
+  - `source_path`
+  - `source_bucket`
+- persist those surfaces without collapsing them into `meta`
+- keep old rows readable
+
+### Success criteria
+
+- all new archive writes can preserve replayable provenance
+- new query surfaces can distinguish semantic text from structured block content
+- no existing import command breaks
+
+## Stage 2: Transition Current Ingest Entry Points to the Archive Spine
+
+### Goals
+
+Move the source-specific parsing burden out of `mychatarchive` and into the
+archive ingest spine while keeping `mychatarchive`’s CLI ergonomics.
+
+### Recommended approach
+
+- wrap `chat-export-structurer` as a library or subprocess-backed adapter
+- keep `mychatarchive import` / `sync` as orchestrators
+- make `mychatarchive` responsible for:
+  - source discovery
+  - source configuration
+  - job orchestration
+  - post-ingest embedding/summarization/index work
+- make the ingest spine responsible for:
+  - parser selection
+  - source normalization
+  - provenance
+  - sidecars
+
+### Why this is the right cut
+
+- avoids dual-maintaining parser logic
+- reuses the already-tested provenance model
+- preserves current UX while changing internals
+
+### Success criteria
+
+- `mychatarchive` can ingest at least the currently supported formats through
+  the spine without regression
+- parser coverage becomes additive instead of forked
+
+## Stage 3: Batch Artifact and Governance Surfaces
+
+### Goals
+
+Make archive batches and follow/review surfaces explicit in `mychatarchive`,
+rather than leaving provenance entirely implicit.
+
+### Deliverables
+
+- awareness of `itir.normalized.artifact.v1`
+- storage or registry for batch sidecars
+- product-level handling of:
+  - `authority_class`
+  - `lineage`
+  - `follow_obligation`
+  - `unresolved_pressure_status`
+
+### Success criteria
+
+- MCP/search surfaces can explain whether data is source-derived, derived, or
+  unresolved
+- archive searches and follow workflows can emit or consume governance-aware
+  artifacts
+
+## Stage 4: Predicate Projection Tables
+
+### Goals
+
+Move beyond storing raw shared-reducer payloads in `messages.meta`, and persist
+bounded, queryable ITIR projections.
+
+### Recommended tables
+
+- `predicate_refs`
+  - predicate ref id
+  - message id / chunk id
+  - predicate signature
+  - polarity
+  - modality
+  - provenance span refs
+- `predicate_roles`
+  - predicate ref id
+  - role name
+  - argument value
+  - argument span refs
+- optional cached `predicate_messages` / `predicate_chunks` bridge tables for
+  faster retrieval
+
+### Success criteria
+
+- `mychatarchive` can answer predicate-level queries without reparsing
+  `messages.meta`
+- projections remain bounded and source-linked
+
+## Stage 5: Residual and Index Layer
+
+### Goals
+
+Make SensibLaw residual-lattice machinery a live retrieval primitive.
+
+### Deliverables
+
+- persistent or rebuildable `PredicateIndex`-style surfaces
+- residual lookup APIs over messages/chunks/threads
+- retrieval questions such as:
+  - what overlaps?
+  - what contradicts?
+  - what remains unresolved?
+  - what needs follow-up?
+
+### Success criteria
+
+- retrieval ranking can use predicate overlap and residuals, not only embeddings
+- context assembly can explain why a result was selected
+
+## Stage 6: Product Use of ITIR Governance and Residuals
+
+### Goals
+
+Use the new surfaces in actual user-visible product behavior.
+
+### Product surfaces
+
+- retrieval ranking and filtering
+- follow-up generation
+- context assembly
+- duplicate/coverage reporting
+- explanation surfaces in MCP responses
+
+### Success criteria
+
+- search/context answers can distinguish:
+  - authoritative source artifacts
+  - derived summaries
+  - unresolved pressure
+  - follow obligations
+
+## Migration Risks
+
+### Risk 1: Forked parser logic
+
+If `mychatarchive` keeps growing its own parser registry while the spine also
+grows, the projects will diverge and provenance behavior will drift.
+
+### Risk 2: Meta-blob stagnation
+
+If `messages.meta["itir"]` remains the only ITIR storage surface, deeper PNF and
+residual work will stay expensive and ad hoc.
+
+### Risk 3: Product features outrun archive truth
+
+If embeddings, summaries, and MCP retrieval continue to evolve without
+archive-truth parity, user-facing answers will look richer than the archive is
+trustworthy.
+
+## Recommended Implementation Order
+
+1. Stage 1: archive-truth parity
+2. Stage 2: route ingest entrypoints through the archive spine
+3. Stage 3: sidecar + governance awareness
+4. Stage 4: predicate projection tables
+5. Stage 5: residual/index layer
+6. Stage 6: product integration
+
+This order matters. Predicate and residual work should not be built on top of
+an archive that still lacks replayable provenance and structured blocks.

--- a/src/mychatarchive/backends/storage/__init__.py
+++ b/src/mychatarchive/backends/storage/__init__.py
@@ -25,6 +25,9 @@ class StorageBackend(Protocol):
         self, con, message_id: str, canonical_thread_id: str,
         platform: str, account_id: str, ts: str, role: str,
         text: str, title: str, source_id: str,
+        source_thread_id: Optional[str] = None,
+        source_message_id: Optional[str] = None,
+        meta: Optional[dict] = None,
     ) -> bool: ...
 
     # Counts

--- a/src/mychatarchive/backends/storage/sqlite.py
+++ b/src/mychatarchive/backends/storage/sqlite.py
@@ -28,6 +28,8 @@ def get_connection(db_path: Path) -> sqlite3.Connection:
     sqlite_vec.load(con)
     con.enable_load_extension(False)
     con.execute("PRAGMA journal_mode=WAL")
+    con.execute("PRAGMA synchronous=NORMAL")
+    con.execute("PRAGMA temp_store=MEMORY")
     return con
 
 
@@ -117,6 +119,25 @@ def _ensure_thread_summaries_v2(con: sqlite3.Connection, dim: int) -> None:
     con.commit()
 
 
+def _ensure_message_meta_column(con: sqlite3.Connection) -> None:
+    cols = {row[1] for row in con.execute("PRAGMA table_info(messages)").fetchall()}
+    if cols and "meta" not in cols:
+        con.execute("ALTER TABLE messages ADD COLUMN meta TEXT")
+        con.commit()
+
+
+def _ensure_message_provenance_columns(con: sqlite3.Connection) -> None:
+    cols = {row[1] for row in con.execute("PRAGMA table_info(messages)").fetchall()}
+    if cols and "source_thread_id" not in cols:
+        con.execute("ALTER TABLE messages ADD COLUMN source_thread_id TEXT")
+    if cols and "source_message_id" not in cols:
+        con.execute("ALTER TABLE messages ADD COLUMN source_message_id TEXT")
+    con.execute(
+        "CREATE INDEX IF NOT EXISTS idx_messages_source_thread_id ON messages(source_thread_id)"
+    )
+    con.commit()
+
+
 def ensure_schema(con: sqlite3.Connection):
     """Create all tables (ingestion + brain). Idempotent."""
     dim = _get_embedding_dim()
@@ -133,7 +154,10 @@ def ensure_schema(con: sqlite3.Connection):
             role TEXT NOT NULL,
             text TEXT NOT NULL,
             title TEXT,
-            source_id TEXT NOT NULL
+            source_id TEXT NOT NULL,
+            source_thread_id TEXT,
+            source_message_id TEXT,
+            meta TEXT
         );
 
         CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts
@@ -190,6 +214,8 @@ def ensure_schema(con: sqlite3.Connection):
     """)
 
     con.commit()
+    _ensure_message_meta_column(con)
+    _ensure_message_provenance_columns(con)
 
     # Thread summaries: create or migrate to multi-segment schema
     _ensure_thread_summaries_v2(con, dim)
@@ -199,18 +225,36 @@ def ensure_schema(con: sqlite3.Connection):
 
 def insert_message(con: sqlite3.Connection, message_id: str, canonical_thread_id: str,
                    platform: str, account_id: str, ts: str, role: str, text: str,
-                   title: str, source_id: str) -> bool:
+                   title: str, source_id: str,
+                   source_thread_id: Optional[str] = None,
+                   source_message_id: Optional[str] = None,
+                   meta: Optional[dict] = None) -> bool:
     """Insert a message. Returns True if inserted, False if duplicate."""
     cur = con.execute(
         "INSERT OR IGNORE INTO messages "
-        "(message_id, canonical_thread_id, platform, account_id, ts, role, text, title, source_id) "
-        "VALUES (?,?,?,?,?,?,?,?,?)",
-        (message_id, canonical_thread_id, platform, account_id, ts, role, text, title, source_id),
+        "("
+        "message_id, canonical_thread_id, platform, account_id, ts, role, text, title, source_id, "
+        "source_thread_id, source_message_id, meta"
+        ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+        (
+            message_id,
+            canonical_thread_id,
+            platform,
+            account_id,
+            ts,
+            role,
+            text,
+            title,
+            source_id,
+            source_thread_id,
+            source_message_id,
+            json.dumps(meta) if meta else None,
+        ),
     )
     if cur.rowcount == 0:
         return False
-    con.execute("INSERT INTO messages_fts (text) VALUES (?)", (text,))
-    fts_rowid = con.execute("SELECT max(rowid) FROM messages_fts").fetchone()[0]
+    fts_cur = con.execute("INSERT INTO messages_fts (text) VALUES (?)", (text,))
+    fts_rowid = fts_cur.lastrowid
     con.execute(
         "INSERT INTO messages_fts_docids (rowid, message_id) VALUES (?,?)",
         (fts_rowid, message_id),
@@ -253,7 +297,8 @@ def platform_counts(con: sqlite3.Connection) -> list[tuple[str, int]]:
 def iter_messages(con: sqlite3.Connection, batch_size: int = 1000):
     cur = con.cursor()
     cur.execute("""
-        SELECT message_id, canonical_thread_id, ts, role, text, title
+        SELECT message_id, canonical_thread_id, ts, role, text, title,
+               source_thread_id, source_message_id, meta
         FROM messages ORDER BY canonical_thread_id, ts
     """)
     while True:
@@ -268,6 +313,9 @@ def iter_messages(con: sqlite3.Connection, batch_size: int = 1000):
                 "role": row[3],
                 "text": row[4],
                 "title": row[5],
+                "source_thread_id": row[6],
+                "source_message_id": row[7],
+                "meta": json.loads(row[8]) if row[8] else None,
             }
 
 
@@ -507,7 +555,7 @@ def export_messages(con: sqlite3.Connection, platform: Optional[str] = None,
                     limit: Optional[int] = None):
     query = """
         SELECT message_id, canonical_thread_id, platform, account_id,
-               ts, role, text, title, source_id
+               ts, role, text, title, source_id, source_thread_id, source_message_id, meta
         FROM messages ORDER BY platform, canonical_thread_id, ts
     """
     params: list = []
@@ -520,7 +568,9 @@ def export_messages(con: sqlite3.Connection, platform: Optional[str] = None,
     rows = con.execute(query, params).fetchall()
     return [
         {"message_id": r[0], "thread_id": r[1], "platform": r[2], "account_id": r[3],
-         "timestamp": r[4], "role": r[5], "content": r[6], "title": r[7], "source_id": r[8]}
+         "timestamp": r[4], "role": r[5], "content": r[6], "title": r[7], "source_id": r[8],
+         "source_thread_id": r[9], "source_message_id": r[10],
+         "meta": json.loads(r[11]) if r[11] else None}
         for r in rows
     ]
 

--- a/src/mychatarchive/backends/storage/sqlite.py
+++ b/src/mychatarchive/backends/storage/sqlite.py
@@ -8,7 +8,7 @@ import re
 import sqlite3
 import struct
 from pathlib import Path
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 import sqlite_vec
 
@@ -132,9 +132,16 @@ def _ensure_message_provenance_columns(con: sqlite3.Connection) -> None:
         con.execute("ALTER TABLE messages ADD COLUMN source_thread_id TEXT")
     if cols and "source_message_id" not in cols:
         con.execute("ALTER TABLE messages ADD COLUMN source_message_id TEXT")
+    if cols and "source_path" not in cols:
+        con.execute("ALTER TABLE messages ADD COLUMN source_path TEXT")
+    if cols and "source_bucket" not in cols:
+        con.execute("ALTER TABLE messages ADD COLUMN source_bucket TEXT")
+    if cols and "provenance_json" not in cols:
+        con.execute("ALTER TABLE messages ADD COLUMN provenance_json TEXT")
     con.execute(
         "CREATE INDEX IF NOT EXISTS idx_messages_source_thread_id ON messages(source_thread_id)"
     )
+    con.execute("CREATE INDEX IF NOT EXISTS idx_messages_source_bucket ON messages(source_bucket)")
     con.commit()
 
 
@@ -157,6 +164,9 @@ def ensure_schema(con: sqlite3.Connection):
             source_id TEXT NOT NULL,
             source_thread_id TEXT,
             source_message_id TEXT,
+            source_path TEXT,
+            source_bucket TEXT,
+            provenance_json TEXT,
             meta TEXT
         );
 
@@ -176,6 +186,65 @@ def ensure_schema(con: sqlite3.Connection):
             text TEXT NOT NULL,
             ts_start TEXT,
             ts_end TEXT,
+            meta TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS message_blocks (
+            block_id TEXT PRIMARY KEY,
+            message_id TEXT NOT NULL,
+            canonical_thread_id TEXT NOT NULL,
+            block_index INTEGER NOT NULL,
+            block_type TEXT NOT NULL,
+            text TEXT NOT NULL,
+            source_path TEXT,
+            source_bucket TEXT,
+            provenance_json TEXT,
+            meta TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS provenance_refs (
+            provenance_ref_id TEXT PRIMARY KEY,
+            message_id TEXT,
+            block_id TEXT,
+            ref_index INTEGER NOT NULL,
+            source_id TEXT,
+            source_thread_id TEXT,
+            source_message_id TEXT,
+            source_path TEXT,
+            source_bucket TEXT,
+            locator_json TEXT,
+            meta TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS predicate_refs (
+            predicate_ref_id TEXT PRIMARY KEY,
+            message_id TEXT NOT NULL,
+            canonical_thread_id TEXT NOT NULL,
+            predicate_ref TEXT NOT NULL,
+            atom_id TEXT,
+            predicate TEXT NOT NULL,
+            structural_signature TEXT,
+            polarity TEXT,
+            modality TEXT,
+            domain TEXT,
+            wrapper_status TEXT,
+            evidence_only INTEGER NOT NULL DEFAULT 1,
+            source_spans_json TEXT,
+            provenance_refs_json TEXT,
+            meta TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS predicate_roles (
+            predicate_role_id TEXT PRIMARY KEY,
+            predicate_ref_id TEXT NOT NULL,
+            message_id TEXT NOT NULL,
+            role_name TEXT NOT NULL,
+            role_value TEXT NOT NULL,
+            role_status TEXT,
+            entity_type TEXT,
+            cardinality TEXT,
+            members_json TEXT,
+            provenance_refs_json TEXT,
             meta TEXT
         );
 
@@ -201,6 +270,32 @@ def ensure_schema(con: sqlite3.Connection):
             added_at TEXT NOT NULL,
             PRIMARY KEY (canonical_thread_id, group_id)
         );
+    """)
+    cur.executescript("""
+        CREATE INDEX IF NOT EXISTS idx_message_blocks_message_id
+        ON message_blocks(message_id);
+        CREATE INDEX IF NOT EXISTS idx_chunks_message_id
+        ON chunks(message_id);
+        CREATE INDEX IF NOT EXISTS idx_chunks_thread_id
+        ON chunks(canonical_thread_id);
+        CREATE INDEX IF NOT EXISTS idx_message_blocks_thread_id
+        ON message_blocks(canonical_thread_id);
+        CREATE INDEX IF NOT EXISTS idx_provenance_refs_message_id
+        ON provenance_refs(message_id);
+        CREATE INDEX IF NOT EXISTS idx_provenance_refs_block_id
+        ON provenance_refs(block_id);
+        CREATE INDEX IF NOT EXISTS idx_predicate_refs_message_id
+        ON predicate_refs(message_id);
+        CREATE INDEX IF NOT EXISTS idx_predicate_refs_signature
+        ON predicate_refs(structural_signature);
+        CREATE INDEX IF NOT EXISTS idx_predicate_refs_message_signature
+        ON predicate_refs(message_id, structural_signature);
+        CREATE INDEX IF NOT EXISTS idx_predicate_roles_predicate_ref_id
+        ON predicate_roles(predicate_ref_id);
+        CREATE INDEX IF NOT EXISTS idx_predicate_roles_message_id
+        ON predicate_roles(message_id);
+        CREATE INDEX IF NOT EXISTS idx_predicate_roles_lookup
+        ON predicate_roles(role_name, role_value, message_id);
     """)
 
     cur.execute(f"""
@@ -228,14 +323,17 @@ def insert_message(con: sqlite3.Connection, message_id: str, canonical_thread_id
                    title: str, source_id: str,
                    source_thread_id: Optional[str] = None,
                    source_message_id: Optional[str] = None,
-                   meta: Optional[dict] = None) -> bool:
+                   meta: Optional[dict] = None,
+                   source_path: Optional[str] = None,
+                   source_bucket: Optional[str] = None,
+                   provenance_json: Optional[dict] = None) -> bool:
     """Insert a message. Returns True if inserted, False if duplicate."""
     cur = con.execute(
         "INSERT OR IGNORE INTO messages "
         "("
         "message_id, canonical_thread_id, platform, account_id, ts, role, text, title, source_id, "
-        "source_thread_id, source_message_id, meta"
-        ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+        "source_thread_id, source_message_id, source_path, source_bucket, provenance_json, meta"
+        ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
         (
             message_id,
             canonical_thread_id,
@@ -248,6 +346,9 @@ def insert_message(con: sqlite3.Connection, message_id: str, canonical_thread_id
             source_id,
             source_thread_id,
             source_message_id,
+            source_path,
+            source_bucket,
+            json.dumps(provenance_json) if provenance_json is not None else None,
             json.dumps(meta) if meta else None,
         ),
     )
@@ -298,7 +399,7 @@ def iter_messages(con: sqlite3.Connection, batch_size: int = 1000):
     cur = con.cursor()
     cur.execute("""
         SELECT message_id, canonical_thread_id, ts, role, text, title,
-               source_thread_id, source_message_id, meta
+               source_thread_id, source_message_id, source_path, source_bucket, provenance_json, meta
         FROM messages ORDER BY canonical_thread_id, ts
     """)
     while True:
@@ -315,7 +416,10 @@ def iter_messages(con: sqlite3.Connection, batch_size: int = 1000):
                 "title": row[5],
                 "source_thread_id": row[6],
                 "source_message_id": row[7],
-                "meta": json.loads(row[8]) if row[8] else None,
+                "source_path": row[8],
+                "source_bucket": row[9],
+                "provenance_json": json.loads(row[10]) if row[10] else None,
+                "meta": json.loads(row[11]) if row[11] else None,
             }
 
 
@@ -555,7 +659,8 @@ def export_messages(con: sqlite3.Connection, platform: Optional[str] = None,
                     limit: Optional[int] = None):
     query = """
         SELECT message_id, canonical_thread_id, platform, account_id,
-               ts, role, text, title, source_id, source_thread_id, source_message_id, meta
+               ts, role, text, title, source_id, source_thread_id, source_message_id,
+               source_path, source_bucket, provenance_json, meta
         FROM messages ORDER BY platform, canonical_thread_id, ts
     """
     params: list = []
@@ -569,9 +674,511 @@ def export_messages(con: sqlite3.Connection, platform: Optional[str] = None,
     return [
         {"message_id": r[0], "thread_id": r[1], "platform": r[2], "account_id": r[3],
          "timestamp": r[4], "role": r[5], "content": r[6], "title": r[7], "source_id": r[8],
-         "source_thread_id": r[9], "source_message_id": r[10],
-         "meta": json.loads(r[11]) if r[11] else None}
+         "source_thread_id": r[9], "source_message_id": r[10], "source_path": r[11],
+         "source_bucket": r[12], "provenance_json": json.loads(r[13]) if r[13] else None,
+         "meta": json.loads(r[14]) if r[14] else None}
         for r in rows
+    ]
+
+
+def insert_message_block(
+    con: sqlite3.Connection,
+    block_id: str,
+    message_id: str,
+    canonical_thread_id: str,
+    block_index: int,
+    block_type: str,
+    text: str,
+    source_path: Optional[str] = None,
+    source_bucket: Optional[str] = None,
+    provenance_json: Optional[dict] = None,
+    meta: Optional[dict] = None,
+) -> bool:
+    """Insert a structured block for a message. Returns False if duplicate block_id."""
+    cur = con.execute(
+        """
+        INSERT OR IGNORE INTO message_blocks
+            (block_id, message_id, canonical_thread_id, block_index, block_type, text,
+             source_path, source_bucket, provenance_json, meta)
+        VALUES (?,?,?,?,?,?,?,?,?,?)
+        """,
+        (
+            block_id,
+            message_id,
+            canonical_thread_id,
+            block_index,
+            block_type,
+            text,
+            source_path,
+            source_bucket,
+            json.dumps(provenance_json) if provenance_json is not None else None,
+            json.dumps(meta) if meta is not None else None,
+        ),
+    )
+    return cur.rowcount > 0
+
+
+def list_message_blocks(
+    con: sqlite3.Connection,
+    message_id: Optional[str] = None,
+    canonical_thread_id: Optional[str] = None,
+) -> list[dict]:
+    sql = """
+        SELECT block_id, message_id, canonical_thread_id, block_index, block_type, text,
+               source_path, source_bucket, provenance_json, meta
+        FROM message_blocks
+    """
+    conditions: list[str] = []
+    params: list = []
+    if message_id is not None:
+        conditions.append("message_id = ?")
+        params.append(message_id)
+    if canonical_thread_id is not None:
+        conditions.append("canonical_thread_id = ?")
+        params.append(canonical_thread_id)
+    if conditions:
+        sql += " WHERE " + " AND ".join(conditions)
+    sql += " ORDER BY message_id, block_index"
+    rows = con.execute(sql, params).fetchall()
+    return [
+        {
+            "block_id": row[0],
+            "message_id": row[1],
+            "canonical_thread_id": row[2],
+            "block_index": row[3],
+            "block_type": row[4],
+            "text": row[5],
+            "source_path": row[6],
+            "source_bucket": row[7],
+            "provenance_json": json.loads(row[8]) if row[8] else None,
+            "meta": json.loads(row[9]) if row[9] else None,
+        }
+        for row in rows
+    ]
+
+
+def insert_provenance_ref(
+    con: sqlite3.Connection,
+    provenance_ref_id: str,
+    message_id: Optional[str],
+    block_id: Optional[str],
+    ref_index: int,
+    source_id: Optional[str] = None,
+    source_thread_id: Optional[str] = None,
+    source_message_id: Optional[str] = None,
+    source_path: Optional[str] = None,
+    source_bucket: Optional[str] = None,
+    locator_json: Optional[dict] = None,
+    meta: Optional[dict] = None,
+) -> bool:
+    """Insert a provenance reference row. Returns False if duplicate provenance_ref_id."""
+    cur = con.execute(
+        """
+        INSERT OR IGNORE INTO provenance_refs
+            (provenance_ref_id, message_id, block_id, ref_index, source_id,
+             source_thread_id, source_message_id, source_path, source_bucket,
+             locator_json, meta)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?)
+        """,
+        (
+            provenance_ref_id,
+            message_id,
+            block_id,
+            ref_index,
+            source_id,
+            source_thread_id,
+            source_message_id,
+            source_path,
+            source_bucket,
+            json.dumps(locator_json) if locator_json is not None else None,
+            json.dumps(meta) if meta is not None else None,
+        ),
+    )
+    return cur.rowcount > 0
+
+
+def list_provenance_refs(
+    con: sqlite3.Connection,
+    message_id: Optional[str] = None,
+    block_id: Optional[str] = None,
+) -> list[dict]:
+    sql = """
+        SELECT provenance_ref_id, message_id, block_id, ref_index, source_id,
+               source_thread_id, source_message_id, source_path, source_bucket,
+               locator_json, meta
+        FROM provenance_refs
+    """
+    conditions: list[str] = []
+    params: list = []
+    if message_id is not None:
+        conditions.append("message_id = ?")
+        params.append(message_id)
+    if block_id is not None:
+        conditions.append("block_id = ?")
+        params.append(block_id)
+    if conditions:
+        sql += " WHERE " + " AND ".join(conditions)
+    sql += " ORDER BY message_id, block_id, ref_index"
+    rows = con.execute(sql, params).fetchall()
+    return [
+        {
+            "provenance_ref_id": row[0],
+            "message_id": row[1],
+            "block_id": row[2],
+            "ref_index": row[3],
+            "source_id": row[4],
+            "source_thread_id": row[5],
+            "source_message_id": row[6],
+            "source_path": row[7],
+            "source_bucket": row[8],
+            "locator_json": json.loads(row[9]) if row[9] else None,
+            "meta": json.loads(row[10]) if row[10] else None,
+        }
+        for row in rows
+    ]
+
+
+def insert_predicate_projection(
+    con: sqlite3.Connection,
+    message_id: str,
+    canonical_thread_id: str,
+    projection: Mapping[str, Any],
+) -> int:
+    """Replace predicate projection rows for one message. Returns predicate count inserted."""
+    predicates = projection.get("predicates")
+    if not isinstance(predicates, list):
+        return 0
+
+    con.execute("DELETE FROM predicate_roles WHERE message_id = ?", (message_id,))
+    con.execute("DELETE FROM predicate_refs WHERE message_id = ?", (message_id,))
+
+    inserted = 0
+    for pred_index, predicate in enumerate(predicates):
+        if not isinstance(predicate, Mapping):
+            continue
+        predicate_ref = str(predicate.get("ref") or f"pred:{pred_index}")
+        predicate_ref_id = f"{message_id}:{predicate_ref}"
+        con.execute(
+            """
+            INSERT OR REPLACE INTO predicate_refs
+                (predicate_ref_id, message_id, canonical_thread_id, predicate_ref, atom_id,
+                 predicate, structural_signature, polarity, modality, domain, wrapper_status,
+                 evidence_only, source_spans_json, provenance_refs_json, meta)
+            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                predicate_ref_id,
+                message_id,
+                canonical_thread_id,
+                predicate_ref,
+                predicate.get("atom_id"),
+                str(predicate.get("predicate") or ""),
+                str(predicate.get("structural_signature") or "") or None,
+                str(predicate.get("polarity") or "") or None,
+                str(predicate.get("modality") or "") or None,
+                str(predicate.get("domain") or "") or None,
+                str((predicate.get("wrapper") or {}).get("status") or "") or None,
+                1 if bool((predicate.get("wrapper") or {}).get("evidence_only", True)) else 0,
+                json.dumps(predicate.get("source_spans")) if predicate.get("source_spans") is not None else None,
+                json.dumps(predicate.get("provenance_refs")) if predicate.get("provenance_refs") is not None else None,
+                json.dumps(
+                    {
+                        "version": projection.get("version"),
+                        "limits": projection.get("limits"),
+                        "counts": projection.get("counts"),
+                    }
+                ),
+            ),
+        )
+        roles = predicate.get("roles")
+        if isinstance(roles, list):
+            for role_index, role in enumerate(roles):
+                if not isinstance(role, Mapping):
+                    continue
+                role_name = str(role.get("name") or "")
+                role_value = str(role.get("value") or "")
+                if not role_name or not role_value:
+                    continue
+                predicate_role_id = f"{predicate_ref_id}:role:{role_index}"
+                con.execute(
+                    """
+                    INSERT OR REPLACE INTO predicate_roles
+                        (predicate_role_id, predicate_ref_id, message_id, role_name, role_value,
+                         role_status, entity_type, cardinality, members_json, provenance_refs_json, meta)
+                    VALUES (?,?,?,?,?,?,?,?,?,?,?)
+                    """,
+                    (
+                        predicate_role_id,
+                        predicate_ref_id,
+                        message_id,
+                        role_name,
+                        role_value,
+                        str(role.get("status") or "") or None,
+                        str(role.get("entity_type") or "") or None,
+                        str(role.get("cardinality") or "") or None,
+                        json.dumps(role.get("members")) if role.get("members") is not None else None,
+                        json.dumps(role.get("provenance_refs")) if role.get("provenance_refs") is not None else None,
+                        json.dumps({}),
+                    ),
+                )
+        inserted += 1
+    return inserted
+
+
+def list_predicate_refs(
+    con: sqlite3.Connection,
+    message_id: Optional[str] = None,
+    canonical_thread_id: Optional[str] = None,
+) -> list[dict]:
+    sql = """
+        SELECT predicate_ref_id, message_id, canonical_thread_id, predicate_ref, atom_id,
+               predicate, structural_signature, polarity, modality, domain, wrapper_status,
+               evidence_only, source_spans_json, provenance_refs_json, meta
+        FROM predicate_refs
+    """
+    conditions: list[str] = []
+    params: list[Any] = []
+    if message_id is not None:
+        conditions.append("message_id = ?")
+        params.append(message_id)
+    if canonical_thread_id is not None:
+        conditions.append("canonical_thread_id = ?")
+        params.append(canonical_thread_id)
+    if conditions:
+        sql += " WHERE " + " AND ".join(conditions)
+    sql += " ORDER BY message_id, predicate_ref"
+    rows = con.execute(sql, params).fetchall()
+    return [
+        {
+            "predicate_ref_id": row[0],
+            "message_id": row[1],
+            "canonical_thread_id": row[2],
+            "predicate_ref": row[3],
+            "atom_id": row[4],
+            "predicate": row[5],
+            "structural_signature": row[6],
+            "polarity": row[7],
+            "modality": row[8],
+            "domain": row[9],
+            "wrapper_status": row[10],
+            "evidence_only": bool(row[11]),
+            "source_spans": json.loads(row[12]) if row[12] else None,
+            "provenance_refs": json.loads(row[13]) if row[13] else None,
+            "meta": json.loads(row[14]) if row[14] else None,
+        }
+        for row in rows
+    ]
+
+
+def list_predicate_roles(
+    con: sqlite3.Connection,
+    predicate_ref_id: Optional[str] = None,
+    message_id: Optional[str] = None,
+) -> list[dict]:
+    sql = """
+        SELECT predicate_role_id, predicate_ref_id, message_id, role_name, role_value,
+               role_status, entity_type, cardinality, members_json, provenance_refs_json, meta
+        FROM predicate_roles
+    """
+    conditions: list[str] = []
+    params: list[Any] = []
+    if predicate_ref_id is not None:
+        conditions.append("predicate_ref_id = ?")
+        params.append(predicate_ref_id)
+    if message_id is not None:
+        conditions.append("message_id = ?")
+        params.append(message_id)
+    if conditions:
+        sql += " WHERE " + " AND ".join(conditions)
+    sql += " ORDER BY predicate_ref_id, role_name, role_value"
+    rows = con.execute(sql, params).fetchall()
+    return [
+        {
+            "predicate_role_id": row[0],
+            "predicate_ref_id": row[1],
+            "message_id": row[2],
+            "role_name": row[3],
+            "role_value": row[4],
+            "role_status": row[5],
+            "entity_type": row[6],
+            "cardinality": row[7],
+            "members": json.loads(row[8]) if row[8] else None,
+            "provenance_refs": json.loads(row[9]) if row[9] else None,
+            "meta": json.loads(row[10]) if row[10] else None,
+        }
+        for row in rows
+    ]
+
+
+def search_predicate_candidates(
+    con: sqlite3.Connection,
+    structural_signatures: list[str],
+    role_arguments: list[str] | None = None,
+    *,
+    limit: int = 20,
+    platform: str | list[str] | None = None,
+    cutoff_iso: str | None = None,
+    group_thread_ids: set[str] | None = None,
+) -> list[dict]:
+    """Return predicate-first message candidates with representative chunks."""
+    if group_thread_ids is not None and not group_thread_ids:
+        return []
+
+    normalized_signatures = sorted({str(sig).strip() for sig in structural_signatures if str(sig).strip()})
+    normalized_role_args = sorted({str(arg).strip() for arg in (role_arguments or []) if str(arg).strip()})
+    if not normalized_signatures and not normalized_role_args:
+        return []
+
+    message_filters = _predicate_message_filter_sql(platform, cutoff_iso, group_thread_ids)
+
+    candidates: dict[str, dict[str, Any]] = {}
+    if normalized_signatures:
+        placeholders = ",".join("?" * len(normalized_signatures))
+        rows = con.execute(
+            f"""
+            SELECT pr.message_id, pr.canonical_thread_id, pr.structural_signature
+            FROM predicate_refs pr
+            JOIN messages m ON pr.message_id = m.message_id
+            WHERE pr.structural_signature IN ({placeholders}) {message_filters['sql']}
+            """,
+            [*normalized_signatures, *message_filters["params"]],
+        ).fetchall()
+        for message_id, canonical_thread_id, structural_signature in rows:
+            if not message_id:
+                continue
+            candidate = candidates.setdefault(
+                message_id,
+                {
+                    "message_id": message_id,
+                    "canonical_thread_id": canonical_thread_id,
+                    "matched_signatures": set(),
+                    "matched_role_arguments": set(),
+                },
+            )
+            if structural_signature:
+                candidate["matched_signatures"].add(structural_signature)
+
+    if normalized_role_args:
+        role_pairs = [
+            tuple(arg.split("|", 1))
+            for arg in normalized_role_args
+            if "|" in arg and all(part.strip() for part in arg.split("|", 1))
+        ]
+        if role_pairs:
+            clause = " OR ".join("(prr.role_name = ? AND prr.role_value = ?)" for _ in role_pairs)
+            rows = con.execute(
+                f"""
+                SELECT prr.message_id, pr.canonical_thread_id, prr.role_name, prr.role_value
+                FROM predicate_roles prr
+                JOIN predicate_refs pr ON prr.predicate_ref_id = pr.predicate_ref_id
+                JOIN messages m ON prr.message_id = m.message_id
+                WHERE ({clause}) {message_filters['sql']}
+                """,
+                [value for pair in role_pairs for value in pair] + message_filters["params"],
+            ).fetchall()
+            for message_id, canonical_thread_id, role_name, role_value in rows:
+                if not message_id:
+                    continue
+                candidate = candidates.setdefault(
+                    message_id,
+                    {
+                        "message_id": message_id,
+                        "canonical_thread_id": canonical_thread_id,
+                        "matched_signatures": set(),
+                        "matched_role_arguments": set(),
+                    },
+                )
+                if role_name and role_value:
+                    candidate["matched_role_arguments"].add(f"{role_name}|{role_value}")
+
+    if not candidates:
+        return []
+
+    rep_rows = _representative_chunks_for_messages(con, list(candidates))
+    rep_by_message = {row["message_id"]: row for row in rep_rows}
+
+    total_sigs = len(normalized_signatures)
+    total_roles = len(normalized_role_args)
+    scored: list[dict] = []
+    for candidate in candidates.values():
+        rep = rep_by_message.get(candidate["message_id"])
+        if not rep:
+            continue
+        matched_signatures = sorted(candidate["matched_signatures"])
+        matched_role_arguments = sorted(candidate["matched_role_arguments"])
+        signature_score = (len(matched_signatures) / total_sigs) if total_sigs else 0.0
+        role_score = (len(matched_role_arguments) / total_roles) if total_roles else 0.0
+        predicate_score = min(1.0, (signature_score * 0.8) + (role_score * 0.2))
+        scored.append(
+            {
+                "message_id": candidate["message_id"],
+                "canonical_thread_id": candidate["canonical_thread_id"],
+                "chunk_id": rep["chunk_id"],
+                "timestamp": rep["ts_start"],
+                "predicate_score": round(predicate_score, 4),
+                "matched_signatures": matched_signatures,
+                "matched_role_arguments": matched_role_arguments,
+            }
+        )
+
+    scored.sort(
+        key=lambda item: (item["predicate_score"], len(item["matched_role_arguments"]), item["timestamp"] or ""),
+        reverse=True,
+    )
+    return scored[:limit]
+
+
+def _predicate_message_filter_sql(
+    platform: str | list[str] | None,
+    cutoff_iso: str | None,
+    group_thread_ids: set[str] | None,
+) -> dict[str, Any]:
+    conditions: list[str] = []
+    params: list[Any] = []
+
+    if platform:
+        platforms = [platform] if isinstance(platform, str) else platform
+        placeholders = ",".join("?" * len(platforms))
+        conditions.append(f"m.platform IN ({placeholders})")
+        params.extend(platforms)
+    if cutoff_iso:
+        conditions.append("m.ts >= ?")
+        params.append(cutoff_iso)
+    if group_thread_ids:
+        placeholders = ",".join("?" * len(group_thread_ids))
+        conditions.append(f"m.canonical_thread_id IN ({placeholders})")
+        params.extend(group_thread_ids)
+
+    if not conditions:
+        return {"sql": "", "params": params}
+    return {"sql": " AND " + " AND ".join(conditions), "params": params}
+
+
+def _representative_chunks_for_messages(
+    con: sqlite3.Connection,
+    message_ids: list[str],
+) -> list[dict]:
+    if not message_ids:
+        return []
+    placeholders = ",".join("?" * len(message_ids))
+    rows = con.execute(
+        f"""
+        SELECT c.message_id, c.chunk_id, c.ts_start
+        FROM chunks c
+        JOIN (
+            SELECT message_id, MIN(chunk_index) AS min_chunk_index
+            FROM chunks
+            WHERE message_id IN ({placeholders})
+            GROUP BY message_id
+        ) first_chunk
+          ON c.message_id = first_chunk.message_id
+         AND c.chunk_index = first_chunk.min_chunk_index
+        """,
+        message_ids,
+    ).fetchall()
+    return [
+        {"message_id": row[0], "chunk_id": row[1], "ts_start": row[2]}
+        for row in rows
     ]
 
 

--- a/src/mychatarchive/cli.py
+++ b/src/mychatarchive/cli.py
@@ -12,6 +12,7 @@ Commands:
     mychatarchive search <query>      Search from the command line
     mychatarchive info                Show archive stats
     mychatarchive mcp-config          Print MCP configuration JSON
+    mychatarchive notebooklm          Pack or ingest NotebookLM source bundles
 """
 
 import argparse
@@ -61,6 +62,13 @@ def main():
     sources_add.add_argument("path", help="Path to file or directory")
     sources_add.add_argument("--format", default=None, help="Force format (chatgpt, anthropic, etc.)")
     sources_add.add_argument("--account", default="main", help="Account identifier")
+
+    sources_add_live = sources_sub.add_parser("add-live", help="Add a named live import source")
+    sources_add_live.add_argument("name", help="Source name (e.g. 'chatgpt-live')")
+    sources_add_live.add_argument("selector", help="Conversation id, URL, or title selector")
+    sources_add_live.add_argument("--provider", default="chatgpt", help="Live provider name")
+    sources_add_live.add_argument("--account", default="main", help="Account identifier")
+    sources_add_live.add_argument("--title", default=None, help="Optional display title")
 
     sources_rm = sources_sub.add_parser("remove", help="Remove a source")
     sources_rm.add_argument("name", help="Source name to remove")
@@ -279,6 +287,37 @@ def main():
     )
     _add_db_arg(mcp_p)
 
+    # --- notebooklm ---
+    notebooklm_p = sub.add_parser("notebooklm", help="Pack and ingest NotebookLM source bundles")
+    notebooklm_sub = notebooklm_p.add_subparsers(dest="notebooklm_command")
+
+    notebooklm_pack = notebooklm_sub.add_parser("pack", help="Run sibling notebooklm-pack")
+    notebooklm_pack.add_argument("repo_list", help="Repo list file or scan root")
+    notebooklm_pack.add_argument("output_dir", help="Output directory for packed sources")
+    notebooklm_pack.add_argument("--max-sources", type=int, default=50, help="Max sources to emit")
+
+    notebooklm_ingest = notebooklm_sub.add_parser("ingest", help="Upload a notebooklm-pack manifest")
+    notebooklm_ingest.add_argument("--manifest", required=True, help="Path to manifest.json")
+    notebooklm_ingest.add_argument("--notebook-id", default=None, help="Existing notebook id")
+    notebooklm_ingest.add_argument("--notebook-url", default=None, help="Existing notebook URL")
+    notebooklm_ingest.add_argument("--notebook-title", default=None, help="Notebook title if creating")
+    notebooklm_ingest.add_argument("--wait-timeout", type=int, default=None, help="Per-source wait timeout")
+    notebooklm_ingest.add_argument("--upload-concurrency", type=int, default=None, help="Upload concurrency")
+    notebooklm_ingest.add_argument("--notebooklm-cli", default=None, help="Path to notebooklm CLI")
+    notebooklm_ingest.add_argument("--output", required=True, help="Output JSON path")
+
+    notebooklm_pack_ingest = notebooklm_sub.add_parser("pack-ingest", help="Pack then upload to NotebookLM")
+    notebooklm_pack_ingest.add_argument("repo_list", help="Repo list file or scan root")
+    notebooklm_pack_ingest.add_argument("output_dir", help="Output directory for packed sources")
+    notebooklm_pack_ingest.add_argument("--max-sources", type=int, default=50, help="Max sources to emit")
+    notebooklm_pack_ingest.add_argument("--notebook-id", default=None, help="Existing notebook id")
+    notebooklm_pack_ingest.add_argument("--notebook-url", default=None, help="Existing notebook URL")
+    notebooklm_pack_ingest.add_argument("--notebook-title", default=None, help="Notebook title if creating")
+    notebooklm_pack_ingest.add_argument("--wait-timeout", type=int, default=None, help="Per-source wait timeout")
+    notebooklm_pack_ingest.add_argument("--upload-concurrency", type=int, default=None, help="Upload concurrency")
+    notebooklm_pack_ingest.add_argument("--notebooklm-cli", default=None, help="Path to notebooklm CLI")
+    notebooklm_pack_ingest.add_argument("--output", required=True, help="Output JSON path")
+
     args = parser.parse_args()
 
     if args.command is None:
@@ -291,6 +330,10 @@ def main():
 
     if args.command == "sources":
         _cmd_sources(args)
+        return
+
+    if args.command == "notebooklm":
+        _cmd_notebooklm(args)
         return
 
     db_path = args.db or get_db_path()
@@ -501,7 +544,7 @@ def _cmd_sync(args, db_path: Path):
 
 
 def _cmd_sources(args):
-    from mychatarchive.config import get_sources, add_source, remove_source, rename_source
+    from mychatarchive.config import add_live_source, add_source, remove_source, rename_source
 
     cmd = args.sources_command
 
@@ -515,6 +558,21 @@ def _cmd_sources(args):
         if args.format:
             print(f"  Format: {args.format}")
         print(f"  Account: {args.account}")
+        print(f"\nUse: mychatarchive import --from {args.name}")
+
+    elif cmd == "add-live":
+        add_live_source(
+            args.name,
+            args.selector,
+            provider=args.provider,
+            account=args.account,
+            title=args.title,
+        )
+        print(f"Live source '{args.name}' added: {args.selector}")
+        print(f"  Provider: {args.provider}")
+        print(f"  Account:  {args.account}")
+        if args.title:
+            print(f"  Title:    {args.title}")
         print(f"\nUse: mychatarchive import --from {args.name}")
 
     elif cmd == "remove":
@@ -569,13 +627,21 @@ def _cmd_sources_list():
         print()
         print(f"  NAMED SOURCES ({len(sources)}):")
         for name, cfg in sources.items():
-            path = cfg.get("path", "?")
-            fmt = cfg.get("format", "auto-detect")
+            source_type = cfg.get("type", "path")
             account = cfg.get("account", "main")
-            exists = "✓" if Path(path).expanduser().exists() else "✗"
             print(f"    {name}")
-            print(f"      Path:    {path} [{exists}]")
-            print(f"      Format:  {fmt}")
+            print(f"      Type:    {source_type}")
+            if source_type == "live":
+                print(f"      Provider: {cfg.get('provider', 'chatgpt')}")
+                print(f"      Selector: {cfg.get('selector', '?')}")
+                if cfg.get("title"):
+                    print(f"      Title:    {cfg.get('title')}")
+            else:
+                path = cfg.get("path", "?")
+                fmt = cfg.get("format", "auto-detect")
+                exists = "✓" if Path(path).expanduser().exists() else "✗"
+                print(f"      Path:    {path} [{exists}]")
+                print(f"      Format:  {fmt}")
             print(f"      Account: {account}")
 
     print(f"{'─' * 60}")
@@ -707,14 +773,21 @@ def _cmd_export(args, db_path: Path):
 
     elif fmt == "csv":
         import csv
+        csv_rows = []
+        for message in messages:
+            row = dict(message)
+            if row.get("meta") is not None:
+                row["meta"] = json.dumps(row["meta"], ensure_ascii=False)
+            csv_rows.append(row)
         with open(output_path, "w", encoding="utf-8", newline="") as f:
             writer = csv.DictWriter(
                 f,
                 fieldnames=["message_id", "thread_id", "platform", "account_id",
-                            "timestamp", "role", "content", "title", "source_id"],
+                            "timestamp", "role", "content", "title", "source_id",
+                            "source_thread_id", "source_message_id", "meta"],
             )
             writer.writeheader()
-            writer.writerows(messages)
+            writer.writerows(csv_rows)
 
         print(f"Exported {len(messages):,} messages to {output_path}")
         if thoughts and args.include_thoughts:
@@ -727,6 +800,51 @@ def _cmd_export(args, db_path: Path):
                 writer.writeheader()
                 writer.writerows(thoughts)
             print(f"  + {len(thoughts):,} thoughts to {thought_path}")
+
+
+def _cmd_notebooklm(args):
+    import subprocess
+
+    repo_root = Path(__file__).resolve().parents[2]
+    notebooklm_pack_repo = repo_root.parent / "notebooklm-pack"
+    pack_bin = notebooklm_pack_repo / "target" / "debug" / "notebooklm-pack"
+    ingest_script = notebooklm_pack_repo / "scripts" / "ingest_manifest.py"
+
+    if args.notebooklm_command is None:
+        print("Use one of: pack, ingest, pack-ingest", file=sys.stderr)
+        sys.exit(1)
+
+    def _run(cmd: list[str]):
+        proc = subprocess.run(cmd, check=False)
+        if proc.returncode != 0:
+            raise SystemExit(proc.returncode)
+
+    if args.notebooklm_command in {"pack", "pack-ingest"}:
+        if not pack_bin.exists():
+            print(f"notebooklm-pack binary not found: {pack_bin}", file=sys.stderr)
+            sys.exit(1)
+        cmd = [str(pack_bin), args.repo_list, args.output_dir, "--max-sources", str(args.max_sources)]
+        _run(cmd)
+
+    if args.notebooklm_command in {"ingest", "pack-ingest"}:
+        manifest = getattr(args, "manifest", None) or str(Path(args.output_dir) / "manifest.json")
+        if not ingest_script.exists():
+            print(f"NotebookLM ingest helper not found: {ingest_script}", file=sys.stderr)
+            sys.exit(1)
+        cmd = [sys.executable, str(ingest_script), "--manifest", manifest, "--output", args.output]
+        if args.notebook_id:
+            cmd.extend(["--notebook-id", args.notebook_id])
+        if args.notebook_url:
+            cmd.extend(["--notebook-url", args.notebook_url])
+        if args.notebook_title:
+            cmd.extend(["--notebook-title", args.notebook_title])
+        if args.wait_timeout is not None:
+            cmd.extend(["--wait-timeout", str(args.wait_timeout)])
+        if args.upload_concurrency is not None:
+            cmd.extend(["--upload-concurrency", str(args.upload_concurrency)])
+        if args.notebooklm_cli:
+            cmd.extend(["--notebooklm-cli", args.notebooklm_cli])
+        _run(cmd)
 
 
 def _cmd_embed(args, db_path: Path):

--- a/src/mychatarchive/cli.py
+++ b/src/mychatarchive/cli.py
@@ -129,6 +129,9 @@ def main():
     # --- embed ---
     embed_p = sub.add_parser("embed", help="Generate vector embeddings for all messages")
     embed_p.add_argument("--batch-size", type=int, default=64, help="Embedding batch size")
+    embed_p.add_argument("--max-messages", type=int, default=None, help="Embed at most this many new messages, then stop cleanly")
+    embed_p.add_argument("--max-chunks", type=int, default=None, help="Embed at most this many new chunks, then stop cleanly")
+    embed_p.add_argument("--progress-interval", type=int, default=10, help="Seconds between progress/ETA log lines")
     embed_p.add_argument("--force", action="store_true", help="Re-embed all messages")
     _add_db_arg(embed_p)
 
@@ -236,7 +239,7 @@ def main():
     search_p.add_argument("--limit", type=int, default=10, help="Max results")
     search_p.add_argument(
         "--mode",
-        choices=["semantic", "keyword"],
+        choices=["semantic", "keyword", "hybrid"],
         default="semantic",
         help="Search mode (default: semantic)",
     )
@@ -853,7 +856,14 @@ def _cmd_embed(args, db_path: Path):
         sys.exit(1)
 
     from mychatarchive.embeddings import run
-    run(db_path=db_path, batch_size=args.batch_size, force=args.force)
+    run(
+        db_path=db_path,
+        batch_size=args.batch_size,
+        force=args.force,
+        max_messages=args.max_messages,
+        max_chunks=args.max_chunks,
+        progress_interval=args.progress_interval,
+    )
 
 
 def _cmd_summarize(args, db_path: Path):
@@ -1122,7 +1132,7 @@ def _cmd_search(args, db_path: Path):
                 print(f"Thread: {title}")
                 print(f"Role: {role} | Time: {row[2]}")
                 print(f"{row[0][:500]}")
-    else:
+    elif args.mode == "keyword":
         results = db.fts_search(
             con, query, limit=args.limit, platform=platform,
             cutoff_iso=cutoff_iso, sort_by_time=sort_by_time,
@@ -1138,6 +1148,39 @@ def _cmd_search(args, db_path: Path):
             print(f"Thread: {row[5] or 'Untitled'}")
             print(f"Role: {row[4]} | Time: {row[3]}")
             print(f"{row[1][:500]}")
+    else:
+        from mychatarchive.embeddings import embed_single
+        from mychatarchive.hybrid_search import search_hybrid
+
+        embedding = embed_single(query)
+        results = search_hybrid(
+            con,
+            query,
+            embedding,
+            limit=args.limit,
+            platform=platform,
+            cutoff_iso=cutoff_iso,
+            sort_by_time=sort_by_time,
+            group_thread_ids=group_thread_ids,
+        )
+        if not results:
+            print("No results found.")
+            con.close()
+            return
+
+        for i, row in enumerate(results, 1):
+            scores = row["scores"]
+            sources = "+".join(row["source"])
+            print(f"\n--- Result {i} (hybrid: {scores['hybrid']}, {sources}) ---")
+            print(f"Thread: {row['title'] or 'Untitled'}")
+            print(f"Role: {row['role'] or '?'} | Time: {row['timestamp']}")
+            print(
+                "Scores: "
+                f"keyword={scores['keyword']} "
+                f"semantic={scores['semantic']} "
+                f"exact={scores['exact']}"
+            )
+            print(f"{row['text'][:500]}")
 
     con.close()
 

--- a/src/mychatarchive/config.py
+++ b/src/mychatarchive/config.py
@@ -11,7 +11,8 @@ Example config.json:
   "drop_folder": "~/.mychatarchive/imports",
   "auto_sources": {"claude_code": true, "cursor": true},
   "sources": {
-    "nas": {"path": "//server.local/share/exports", "format": "chatgpt"}
+    "nas": {"type": "path", "path": "//server.local/share/exports", "format": "chatgpt"},
+    "chatgpt_live": {"type": "live", "provider": "chatgpt", "selector": "Project chat"}
   },
   "summarize": {
     "api_key": "sk-or-...",
@@ -23,6 +24,7 @@ Example config.json:
 """
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -168,9 +170,30 @@ def get_source(name: str) -> dict | None:
 def add_source(name: str, path: str, format_name: str | None = None, account: str = "main"):
     cfg = load_config()
     sources = cfg.setdefault("sources", {})
-    entry: dict = {"path": path, "account": account}
+    entry: dict = {"type": "path", "path": path, "account": account}
     if format_name:
         entry["format"] = format_name
+    sources[name] = entry
+    save_config(cfg)
+
+
+def add_live_source(
+    name: str,
+    selector: str,
+    provider: str = "chatgpt",
+    account: str = "main",
+    title: str | None = None,
+):
+    cfg = load_config()
+    sources = cfg.setdefault("sources", {})
+    entry: dict = {
+        "type": "live",
+        "provider": provider,
+        "selector": selector,
+        "account": account,
+    }
+    if title:
+        entry["title"] = title
     sources[name] = entry
     save_config(cfg)
 
@@ -193,3 +216,41 @@ def rename_source(old_name: str, new_name: str) -> bool:
     sources[new_name] = sources.pop(old_name)
     save_config(cfg)
     return True
+
+
+def get_itir_paths() -> list[Path]:
+    """Return configured ITIR/SensibLaw roots in priority order."""
+    cfg = load_config()
+    configured = cfg.get("itir", {}).get("paths", [])
+    if configured:
+        return [Path(path).expanduser() for path in configured]
+
+    env_value = os.environ.get("MYCHATARCHIVE_ITIR_PATHS", "").strip()
+    if env_value:
+        return [Path(path).expanduser() for path in env_value.split(os.pathsep) if path.strip()]
+
+    repo_root = Path(__file__).resolve().parents[2]
+    defaults = [
+        repo_root.parent / "ITIR-suite" / "SensibLaw",
+        Path.home() / "Documents" / "code" / "ITIR-suite" / "SensibLaw",
+    ]
+    return [path for path in defaults if path.exists()]
+
+
+def get_re_gpt_roots() -> list[Path]:
+    """Return candidate reverse-engineered-chatgpt roots in priority order."""
+    cfg = load_config()
+    configured = cfg.get("live", {}).get("re_gpt_paths", [])
+    if configured:
+        return [Path(path).expanduser() for path in configured]
+
+    env_value = os.environ.get("MYCHATARCHIVE_RE_GPT_PATHS", "").strip()
+    if env_value:
+        return [Path(path).expanduser() for path in env_value.split(os.pathsep) if path.strip()]
+
+    repo_root = Path(__file__).resolve().parents[2]
+    defaults = [
+        repo_root.parent / "ITIR-suite" / "reverse-engineered-chatgpt",
+        Path.home() / "Documents" / "code" / "ITIR-suite" / "reverse-engineered-chatgpt",
+    ]
+    return [path for path in defaults if path.exists()]

--- a/src/mychatarchive/db.py
+++ b/src/mychatarchive/db.py
@@ -30,10 +30,13 @@ def ensure_schema(con) -> None:
 
 def insert_message(con, message_id: str, canonical_thread_id: str,
                    platform: str, account_id: str, ts: str, role: str,
-                   text: str, title: str, source_id: str) -> bool:
+                   text: str, title: str, source_id: str,
+                   source_thread_id: Optional[str] = None,
+                   source_message_id: Optional[str] = None,
+                   meta: Optional[dict] = None) -> bool:
     return _b().insert_message(
         con, message_id, canonical_thread_id, platform, account_id,
-        ts, role, text, title, source_id,
+        ts, role, text, title, source_id, source_thread_id, source_message_id, meta,
     )
 
 

--- a/src/mychatarchive/db.py
+++ b/src/mychatarchive/db.py
@@ -33,10 +33,14 @@ def insert_message(con, message_id: str, canonical_thread_id: str,
                    text: str, title: str, source_id: str,
                    source_thread_id: Optional[str] = None,
                    source_message_id: Optional[str] = None,
-                   meta: Optional[dict] = None) -> bool:
+                   meta: Optional[dict] = None,
+                   source_path: Optional[str] = None,
+                   source_bucket: Optional[str] = None,
+                   provenance_json: Optional[dict] = None) -> bool:
     return _b().insert_message(
         con, message_id, canonical_thread_id, platform, account_id,
         ts, role, text, title, source_id, source_thread_id, source_message_id, meta,
+        source_path, source_bucket, provenance_json,
     )
 
 
@@ -151,6 +155,138 @@ def export_messages(con, platform: str | None = None, limit: int | None = None):
 
 def export_thoughts(con):
     return _b().export_thoughts(con)
+
+
+def insert_message_block(
+    con,
+    block_id: str,
+    message_id: str,
+    canonical_thread_id: str,
+    block_index: int,
+    block_type: str,
+    text: str,
+    source_path: Optional[str] = None,
+    source_bucket: Optional[str] = None,
+    provenance_json: Optional[dict] = None,
+    meta: Optional[dict] = None,
+) -> bool:
+    return _b().insert_message_block(
+        con,
+        block_id,
+        message_id,
+        canonical_thread_id,
+        block_index,
+        block_type,
+        text,
+        source_path,
+        source_bucket,
+        provenance_json,
+        meta,
+    )
+
+
+def list_message_blocks(
+    con,
+    message_id: Optional[str] = None,
+    canonical_thread_id: Optional[str] = None,
+) -> list[dict]:
+    return _b().list_message_blocks(
+        con,
+        message_id=message_id,
+        canonical_thread_id=canonical_thread_id,
+    )
+
+
+def insert_provenance_ref(
+    con,
+    provenance_ref_id: str,
+    message_id: Optional[str],
+    block_id: Optional[str],
+    ref_index: int,
+    source_id: Optional[str] = None,
+    source_thread_id: Optional[str] = None,
+    source_message_id: Optional[str] = None,
+    source_path: Optional[str] = None,
+    source_bucket: Optional[str] = None,
+    locator_json: Optional[dict] = None,
+    meta: Optional[dict] = None,
+) -> bool:
+    return _b().insert_provenance_ref(
+        con,
+        provenance_ref_id,
+        message_id,
+        block_id,
+        ref_index,
+        source_id,
+        source_thread_id,
+        source_message_id,
+        source_path,
+        source_bucket,
+        locator_json,
+        meta,
+    )
+
+
+def list_provenance_refs(
+    con,
+    message_id: Optional[str] = None,
+    block_id: Optional[str] = None,
+) -> list[dict]:
+    return _b().list_provenance_refs(con, message_id=message_id, block_id=block_id)
+
+
+def insert_predicate_projection(
+    con,
+    message_id: str,
+    canonical_thread_id: str,
+    projection: dict,
+) -> int:
+    return _b().insert_predicate_projection(con, message_id, canonical_thread_id, projection)
+
+
+def list_predicate_refs(
+    con,
+    message_id: Optional[str] = None,
+    canonical_thread_id: Optional[str] = None,
+) -> list[dict]:
+    return _b().list_predicate_refs(
+        con,
+        message_id=message_id,
+        canonical_thread_id=canonical_thread_id,
+    )
+
+
+def list_predicate_roles(
+    con,
+    predicate_ref_id: Optional[str] = None,
+    message_id: Optional[str] = None,
+) -> list[dict]:
+    return _b().list_predicate_roles(
+        con,
+        predicate_ref_id=predicate_ref_id,
+        message_id=message_id,
+    )
+
+
+def search_predicate_candidates(
+    con,
+    structural_signatures: list[str],
+    role_arguments: Optional[list[str]] = None,
+    *,
+    limit: int = 20,
+    platform: str | list[str] | None = None,
+    cutoff_iso: str | None = None,
+    group_thread_ids: set[str] | None = None,
+) -> list[dict]:
+    return _b().search_predicate_candidates(
+        con,
+        structural_signatures,
+        role_arguments,
+        limit=limit,
+        platform=platform,
+        cutoff_iso=cutoff_iso,
+        group_thread_ids=group_thread_ids,
+    )
 
 
 # ── Thread summaries ──────────────────────────────────────────────────────────

--- a/src/mychatarchive/embeddings.py
+++ b/src/mychatarchive/embeddings.py
@@ -8,6 +8,7 @@ multiple overlapping chunks so no content is discarded.
 
 import hashlib
 import sys
+import time
 from pathlib import Path
 
 from tqdm import tqdm
@@ -38,7 +39,25 @@ def embed_single(text: str) -> list[float]:
 # Main pipeline
 # ---------------------------------------------------------------------------
 
-def run(db_path: Path, batch_size: int = 64, force: bool = False):
+def _format_duration(seconds: float) -> str:
+    seconds = max(0, int(seconds))
+    hours, rem = divmod(seconds, 3600)
+    minutes, secs = divmod(rem, 60)
+    if hours:
+        return f"{hours}h{minutes:02d}m{secs:02d}s"
+    if minutes:
+        return f"{minutes}m{secs:02d}s"
+    return f"{secs}s"
+
+
+def run(
+    db_path: Path,
+    batch_size: int = 64,
+    force: bool = False,
+    max_messages: int | None = None,
+    max_chunks: int | None = None,
+    progress_interval: int = 10,
+):
     con = db.get_connection(db_path)
     db.ensure_schema(con)
 
@@ -73,9 +92,13 @@ def run(db_path: Path, batch_size: int = 64, force: bool = False):
     messages_embedded = 0
     chunks_embedded = 0
     skipped = 0
+    scanned = 0
+    started = time.monotonic()
+    last_progress = started
 
     pbar = tqdm(total=total, desc="Embedding", file=sys.stderr)
     for msg in db.iter_messages(con):
+        scanned += 1
         pbar.update(1)
 
         if msg["message_id"] in already_embedded:
@@ -87,7 +110,22 @@ def run(db_path: Path, batch_size: int = 64, force: bool = False):
             skipped += 1
             continue
 
+        if max_messages is not None and messages_embedded >= max_messages:
+            print(
+                f"Reached --max-messages={max_messages}; stop point is resumable.",
+                file=sys.stderr,
+            )
+            break
+
         chunks = chunk_text(text, chunk_size=chunk_size, overlap=overlap)
+
+        pending_chunks = chunks_embedded + len(batch)
+        if max_chunks is not None and pending_chunks + len(chunks) > max_chunks:
+            print(
+                f"Reached --max-chunks={max_chunks}; stop point is resumable.",
+                file=sys.stderr,
+            )
+            break
 
         for idx, chunk in enumerate(chunks):
             batch.append((chunk, msg, idx))
@@ -97,6 +135,25 @@ def run(db_path: Path, batch_size: int = 64, force: bool = False):
         if len(batch) >= batch_size:
             chunks_embedded += _flush_batch(con, batch)
             batch = []
+
+        now = time.monotonic()
+        if progress_interval > 0 and now - last_progress >= progress_interval:
+            elapsed = now - started
+            rate = scanned / elapsed if elapsed else 0.0
+            remaining_messages = max(total - scanned, 0)
+            eta = remaining_messages / rate if rate else 0.0
+            print(
+                "Progress: "
+                f"scanned={scanned}/{total} "
+                f"embedded_messages={messages_embedded} "
+                f"chunks={chunks_embedded + len(batch)} "
+                f"skipped={skipped} "
+                f"rate={rate:.1f} msg/s "
+                f"eta={_format_duration(eta)}",
+                file=sys.stderr,
+                flush=True,
+            )
+            last_progress = now
 
     if batch:
         chunks_embedded += _flush_batch(con, batch)

--- a/src/mychatarchive/hybrid_search.py
+++ b/src/mychatarchive/hybrid_search.py
@@ -1,0 +1,286 @@
+"""Hybrid keyword/vector retrieval for agent-facing archive search."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable
+
+
+@dataclass
+class HybridSearchResult:
+    """Normalized search result with preserved score components."""
+
+    result_id: str
+    match_key: str
+    thread_id: str
+    message_id: str | None
+    chunk_id: str | None
+    text: str
+    title: str
+    role: str
+    timestamp: str | None
+    source: list[str] = field(default_factory=list)
+    keyword_rank: int | None = None
+    semantic_rank: int | None = None
+    keyword_score: float = 0.0
+    semantic_score: float = 0.0
+    exact_score: float = 0.0
+    hybrid_score: float = 0.0
+    distance: float | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "result_id": self.result_id,
+            "match_key": self.match_key,
+            "thread_id": self.thread_id,
+            "message_id": self.message_id,
+            "chunk_id": self.chunk_id,
+            "title": self.title,
+            "role": self.role,
+            "timestamp": self.timestamp,
+            "text": self.text,
+            "source": self.source,
+            "scores": {
+                "hybrid": round(self.hybrid_score, 4),
+                "keyword": round(self.keyword_score, 4),
+                "semantic": round(self.semantic_score, 4),
+                "exact": round(self.exact_score, 4),
+                "distance": round(self.distance, 6) if self.distance is not None else None,
+                "keyword_rank": self.keyword_rank,
+                "semantic_rank": self.semantic_rank,
+            },
+        }
+
+
+def _safe_lower(value: str | None) -> str:
+    return (value or "").lower()
+
+
+def _match_key(*, message_id: str | None, thread_id: str, chunk_id: str | None = None) -> str:
+    if message_id:
+        return f"message:{message_id}"
+    if thread_id:
+        return f"thread:{thread_id}"
+    return f"chunk:{chunk_id or ''}"
+
+
+def _exact_score(query: str, result: HybridSearchResult) -> float:
+    query_text = query.strip().lower()
+    if not query_text:
+        return 0.0
+
+    identifiers = [
+        result.message_id,
+        result.thread_id,
+        result.chunk_id,
+        result.title,
+    ]
+    if any(query_text == _safe_lower(identifier) for identifier in identifiers):
+        return 1.0
+    if any(query_text and query_text in _safe_lower(identifier) for identifier in identifiers):
+        return 0.75
+    if query_text in _safe_lower(result.text):
+        return 0.55
+
+    tokens = [token for token in query_text.replace("_", " ").replace("-", " ").split() if token]
+    if not tokens:
+        return 0.0
+    identifier_blob = " ".join(_safe_lower(identifier) for identifier in identifiers if identifier)
+    if any(token in identifier_blob for token in tokens if len(token) >= 4):
+        return 0.35
+    return 0.0
+
+
+def keyword_candidates(rows: Iterable[Any], query: str) -> list[HybridSearchResult]:
+    """Adapt db.fts_search rows to normalized candidates.
+
+    Expected row shape: (message_id, text, canonical_thread_id, ts, role, title).
+    """
+    candidates: list[HybridSearchResult] = []
+    for rank, row in enumerate(rows, 1):
+        message_id = row[0]
+        text = row[1] or ""
+        thread_id = row[2] or ""
+        result = HybridSearchResult(
+            result_id=message_id or thread_id,
+            match_key=_match_key(message_id=message_id, thread_id=thread_id),
+            thread_id=thread_id,
+            message_id=message_id,
+            chunk_id=None,
+            text=text,
+            title=row[5] or "",
+            role=row[4] or "",
+            timestamp=row[3],
+            source=["keyword"],
+            keyword_rank=rank,
+            keyword_score=1.0 / rank,
+        )
+        result.exact_score = _exact_score(query, result)
+        candidates.append(result)
+    return candidates
+
+
+def semantic_candidates(
+    con: Any,
+    rows: Iterable[tuple[str, float]],
+    query: str,
+) -> list[HybridSearchResult]:
+    """Adapt vector chunk rows to normalized candidates using the current schema."""
+    raw_rows = list(rows)
+    if not raw_rows:
+        return []
+
+    chunk_ids = [chunk_id for chunk_id, _ in raw_rows]
+    placeholders = ",".join("?" for _ in chunk_ids)
+    records = con.execute(
+        f"""
+        SELECT c.chunk_id, c.message_id, c.canonical_thread_id, c.text, c.ts_start,
+               c.meta, m.role, m.title
+        FROM chunks c
+        LEFT JOIN messages m ON m.message_id = c.message_id
+        WHERE c.chunk_id IN ({placeholders})
+        """,
+        chunk_ids,
+    ).fetchall()
+    by_chunk_id = {row[0]: row for row in records}
+
+    candidates: list[HybridSearchResult] = []
+    for rank, (chunk_id, distance) in enumerate(raw_rows, 1):
+        record = by_chunk_id.get(chunk_id)
+        if not record:
+            continue
+        semantic_score = max(0.0, 1.0 - float(distance))
+        result = HybridSearchResult(
+            result_id=record[1] or chunk_id,
+            match_key=_match_key(
+                message_id=record[1],
+                thread_id=record[2] or "",
+                chunk_id=chunk_id,
+            ),
+            thread_id=record[2] or "",
+            message_id=record[1],
+            chunk_id=chunk_id,
+            text=record[3] or "",
+            title=record[7] or "",
+            role=record[6] or "",
+            timestamp=record[4],
+            source=["semantic"],
+            semantic_rank=rank,
+            semantic_score=semantic_score,
+            distance=float(distance),
+        )
+        result.exact_score = _exact_score(query, result)
+        candidates.append(result)
+    return candidates
+
+
+def merge_candidates(
+    keyword: Iterable[HybridSearchResult],
+    semantic: Iterable[HybridSearchResult],
+    *,
+    query: str,
+    limit: int,
+) -> list[HybridSearchResult]:
+    """Merge FTS and semantic candidates while preserving exact/keyword priority."""
+    merged: dict[str, HybridSearchResult] = {}
+
+    for candidate in [*keyword, *semantic]:
+        candidate.exact_score = max(candidate.exact_score, _exact_score(query, candidate))
+        existing = merged.get(candidate.match_key)
+        if existing is None:
+            merged[candidate.match_key] = candidate
+            continue
+
+        if "keyword" in candidate.source and "keyword" not in existing.source:
+            existing.source.append("keyword")
+        if "semantic" in candidate.source and "semantic" not in existing.source:
+            existing.source.append("semantic")
+
+        existing.keyword_score = max(existing.keyword_score, candidate.keyword_score)
+        existing.semantic_score = max(existing.semantic_score, candidate.semantic_score)
+        existing.exact_score = max(existing.exact_score, candidate.exact_score)
+        existing.keyword_rank = min(
+            rank for rank in [existing.keyword_rank, candidate.keyword_rank] if rank is not None
+        ) if existing.keyword_rank is not None or candidate.keyword_rank is not None else None
+        existing.semantic_rank = min(
+            rank for rank in [existing.semantic_rank, candidate.semantic_rank] if rank is not None
+        ) if existing.semantic_rank is not None or candidate.semantic_rank is not None else None
+        if candidate.distance is not None:
+            existing.distance = (
+                candidate.distance
+                if existing.distance is None
+                else min(existing.distance, candidate.distance)
+            )
+        if candidate.chunk_id and not existing.chunk_id:
+            existing.chunk_id = candidate.chunk_id
+        if len(candidate.text) > len(existing.text) and "keyword" not in existing.source:
+            existing.text = candidate.text
+
+    for result in merged.values():
+        source_bonus = 0.15 if {"keyword", "semantic"}.issubset(set(result.source)) else 0.0
+        result.hybrid_score = (
+            result.keyword_score * 1.15
+            + result.semantic_score * 0.75
+            + result.exact_score * 1.35
+            + source_bonus
+        )
+
+    ranked = sorted(
+        merged.values(),
+        key=lambda item: (
+            item.hybrid_score,
+            item.exact_score,
+            item.keyword_score,
+            item.semantic_score,
+            item.timestamp or "",
+        ),
+        reverse=True,
+    )
+    return ranked[:limit]
+
+
+def search_hybrid(
+    con: Any,
+    query: str,
+    embedding: list[float],
+    *,
+    limit: int = 10,
+    platform: str | list[str] | None = None,
+    cutoff_iso: str | None = None,
+    sort_by_time: bool = False,
+    group_thread_ids: set[str] | None = None,
+    keyword_search: Callable[..., list[Any]] | None = None,
+    semantic_search: Callable[..., list[tuple[str, float]]] | None = None,
+) -> list[dict[str, Any]]:
+    """Run hybrid retrieval and return JSON-ready result dictionaries."""
+    from mychatarchive import db
+
+    keyword_search = keyword_search or db.fts_search
+    semantic_search = semantic_search or db.search_chunks
+    candidate_limit = max(limit * 4, 20)
+
+    keyword_rows = keyword_search(
+        con,
+        query,
+        limit=candidate_limit,
+        platform=platform,
+        cutoff_iso=cutoff_iso,
+        sort_by_time=sort_by_time,
+        group_thread_ids=group_thread_ids,
+    )
+    semantic_rows = semantic_search(
+        con,
+        embedding,
+        limit=candidate_limit,
+        platform=platform,
+        cutoff_iso=cutoff_iso,
+        sort_by_time=sort_by_time,
+        group_thread_ids=group_thread_ids,
+    )
+    results = merge_candidates(
+        keyword_candidates(keyword_rows, query),
+        semantic_candidates(con, semantic_rows, query),
+        query=query,
+        limit=limit,
+    )
+    return [result.as_dict() for result in results]

--- a/src/mychatarchive/ingest.py
+++ b/src/mychatarchive/ingest.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from tqdm import tqdm
 
 from mychatarchive import db
+from mychatarchive.itir import enrich_text as enrich_text_with_itir
+from mychatarchive.live import choose_live_selector, fetch_live_messages
 from mychatarchive.parsers import parse, detect_format
 
 IMPORTABLE_EXTENSIONS = {".json", ".jsonl"}
@@ -46,6 +48,121 @@ def round_epoch(ts) -> int | None:
         return None
 
 
+def _build_message_meta(content: str | None) -> dict | None:
+    if not content or not content.strip():
+        return None
+    itir_payload = enrich_text_with_itir(content)
+    return {"itir": itir_payload}
+
+
+def _canonical_thread_id_for_messages(
+    thread_messages: list[dict],
+    *,
+    platform: str,
+    account_id: str,
+) -> str:
+    first = thread_messages[0]
+    thread_source_id = str(first.get("thread_id") or "").strip()
+    if thread_source_id:
+        return sha1("|".join([platform, account_id, "source_thread_id", thread_source_id]))
+
+    first_snip = (first["content"] or "")[:256]
+    return sha1("|".join([
+        platform,
+        account_id,
+        norm_text(first["thread_title"]),
+        str(round_epoch(first["created_at"]) or ""),
+        first["role"] or "",
+        norm_text(first_snip),
+    ]))
+
+
+def _message_id_for_message(
+    msg: dict,
+    *,
+    platform: str,
+    account_id: str,
+    canonical_thread_id: str,
+) -> str:
+    source_message_id = str(msg.get("source_message_id") or "").strip()
+    if source_message_id:
+        return sha1("|".join([
+            platform, account_id, canonical_thread_id, "source_message_id", source_message_id,
+        ]))
+
+    ts_round = round_epoch(msg["created_at"]) or 0
+    return sha1("|".join([
+        platform, account_id, canonical_thread_id, msg["role"] or "",
+        str(ts_round), norm_text(msg["content"] or ""),
+    ]))
+
+
+def ingest_parsed_messages(
+    messages: list[dict],
+    *,
+    db_path: Path,
+    platform: str,
+    account_id: str = "main",
+    source_id: str,
+):
+    """Insert already-parsed messages while preserving upstream provenance."""
+    con = db.get_connection(db_path)
+    db.ensure_schema(con)
+
+    if not messages:
+        con.close()
+        return 0, 0
+
+    threads: dict[str, list[dict]] = {}
+    for msg in messages:
+        threads.setdefault(str(msg["thread_id"]), []).append(msg)
+
+    inserted = 0
+    duplicates = 0
+    for _tid, thread_messages in tqdm(threads.items(), desc="Importing", file=sys.stderr):
+        thread_messages.sort(key=lambda m: m["created_at"])
+        canonical_thread_id = _canonical_thread_id_for_messages(
+            thread_messages,
+            platform=platform,
+            account_id=account_id,
+        )
+
+        for msg in thread_messages:
+            ts_iso = iso_from_epoch(msg["created_at"])
+            if not ts_iso:
+                continue
+            message_id = _message_id_for_message(
+                msg,
+                platform=platform,
+                account_id=account_id,
+                canonical_thread_id=canonical_thread_id,
+            )
+            message_meta = _build_message_meta(msg["content"] or "")
+            was_inserted = db.insert_message(
+                con,
+                message_id,
+                canonical_thread_id,
+                platform,
+                account_id,
+                ts_iso,
+                msg["role"] or "",
+                msg["content"] or "",
+                msg.get("thread_title"),
+                source_id,
+                str(msg.get("thread_id") or "") or None,
+                str(msg.get("source_message_id") or "") or None,
+                message_meta,
+            )
+            if was_inserted:
+                inserted += 1
+            else:
+                duplicates += 1
+        con.commit()
+
+    con.close()
+    return inserted, duplicates
+
+
 def run(
     file_path: Path,
     db_path: Path,
@@ -69,66 +186,25 @@ def run(
     platform = platform or format_name
     source_id = source_id or f"import_{file_path.stem if not is_auto else format_name}"
 
-    con = db.get_connection(db_path)
-    db.ensure_schema(con)
-
     print(f"Parsing {format_name} export: {file_path}", file=sys.stderr)
     messages = list(parse(file_path, format_name))
 
     if not messages:
         print("No messages found in export.", file=sys.stderr)
-        con.close()
         return 0, 0
 
     thread_ids = set(m["thread_id"] for m in messages)
     print(f"Found {len(messages)} messages in {len(thread_ids)} threads.", file=sys.stderr)
 
-    # Group by thread
-    threads: dict[str, list[dict]] = {}
-    for msg in messages:
-        threads.setdefault(msg["thread_id"], []).append(msg)
-
-    inserted = 0
-    duplicates = 0
-
-    for _tid, thread_messages in tqdm(threads.items(), desc="Importing", file=sys.stderr):
-        thread_messages.sort(key=lambda m: m["created_at"])
-        first = thread_messages[0]
-        first_snip = (first["content"] or "")[:256]
-
-        canonical_thread_id = sha1("|".join([
-            platform,
-            account_id,
-            norm_text(first["thread_title"]),
-            str(round_epoch(first["created_at"]) or ""),
-            first["role"] or "",
-            norm_text(first_snip),
-        ]))
-
-        for msg in thread_messages:
-            ts_round = round_epoch(msg["created_at"]) or 0
-            message_id = sha1("|".join([
-                platform, account_id, canonical_thread_id, msg["role"] or "",
-                str(ts_round), norm_text(msg["content"] or ""),
-            ]))
-
-            ts_iso = iso_from_epoch(msg["created_at"])
-            if not ts_iso:
-                continue
-
-            was_inserted = db.insert_message(
-                con, message_id, canonical_thread_id, platform, account_id,
-                ts_iso, msg["role"] or "", msg["content"] or "",
-                msg["thread_title"], source_id,
-            )
-
-            if was_inserted:
-                inserted += 1
-            else:
-                duplicates += 1
-
-        con.commit()
-
+    inserted, duplicates = ingest_parsed_messages(
+        messages,
+        db_path=db_path,
+        platform=platform,
+        account_id=account_id,
+        source_id=source_id,
+    )
+    con = db.get_connection(db_path)
+    db.ensure_schema(con)
     total = db.message_count(con)
     con.close()
 
@@ -211,13 +287,17 @@ def run_source(
         print(f"Unknown source '{source_name}'. Run 'mychatarchive sources list'.", file=sys.stderr)
         return 0, 0
 
+    fmt = src.get("format")
+    account = src.get("account", "main")
+    source_type = src.get("type", "path")
+
+    if source_type == "live":
+        return run_live_source(source_name, db_path)
+
     path = Path(src["path"]).expanduser()
     if not path.exists():
         print(f"Source path does not exist: {path}", file=sys.stderr)
         return 0, 0
-
-    fmt = src.get("format")
-    account = src.get("account", "main")
 
     print(f"Importing from source '{source_name}' ({path})", file=sys.stderr)
 
@@ -234,6 +314,48 @@ def run_source(
             source_id=f"source_{source_name}",
         )
         return result or (0, 0)
+
+
+def run_live_source(source_name: str, db_path: Path):
+    """Import from a named live source using DB-first selector resolution."""
+    from mychatarchive.config import get_source
+
+    src = get_source(source_name)
+    if src is None:
+        print(f"Unknown source '{source_name}'. Run 'mychatarchive sources list'.", file=sys.stderr)
+        return 0, 0
+
+    provider = src.get("provider", "chatgpt")
+    selector = src.get("selector")
+    account = src.get("account", "main")
+    if not selector:
+        print(f"Live source '{source_name}' is missing a selector.", file=sys.stderr)
+        return 0, 0
+
+    resolved_selector, resolution_meta = choose_live_selector(db_path, selector)
+    print(
+        f"Importing live source '{source_name}' via {provider} "
+        f"(selector={selector!r}, resolved={resolved_selector!r})",
+        file=sys.stderr,
+    )
+
+    messages, live_meta = fetch_live_messages(provider, resolved_selector)
+    for message in messages:
+        if not message.get("thread_title") and src.get("title"):
+            message["thread_title"] = src["title"]
+
+    inserted, duplicates = ingest_parsed_messages(
+        messages,
+        db_path=db_path,
+        platform=provider,
+        account_id=account,
+        source_id=f"live_{source_name}",
+    )
+    print(
+        f"  Resolution: {resolution_meta.get('resolution')} -> {live_meta.get('provider_resolution')}",
+        file=sys.stderr,
+    )
+    return inserted, duplicates
 
 
 def run_auto_source(format_name: str, db_path: Path):

--- a/src/mychatarchive/ingest.py
+++ b/src/mychatarchive/ingest.py
@@ -3,17 +3,27 @@
 import hashlib
 import re
 import datetime
+import inspect
 import sys
 from pathlib import Path
+from typing import Any
 
 from tqdm import tqdm
 
 from mychatarchive import db
+from mychatarchive.backends import get_storage
 from mychatarchive.itir import enrich_text as enrich_text_with_itir
 from mychatarchive.live import choose_live_selector, fetch_live_messages
 from mychatarchive.parsers import parse, detect_format
 
 IMPORTABLE_EXTENSIONS = {".json", ".jsonl"}
+OPTIONAL_ARCHIVE_TRUTH_FIELDS = (
+    "source_path",
+    "source_bucket",
+    "provenance_json",
+    "content_blocks",
+    "provenance_refs",
+)
 
 
 def norm_text(s: str | None) -> str:
@@ -53,6 +63,179 @@ def _build_message_meta(content: str | None) -> dict | None:
         return None
     itir_payload = enrich_text_with_itir(content)
     return {"itir": itir_payload}
+
+
+def _extract_optional_archive_fields(msg: dict[str, Any]) -> dict[str, Any]:
+    fields: dict[str, Any] = {}
+    for key in OPTIONAL_ARCHIVE_TRUTH_FIELDS:
+        value = msg.get(key)
+        if value is not None:
+            fields[key] = value
+    return fields
+
+
+def _legacy_meta_with_archive_truth(
+    message_meta: dict[str, Any] | None,
+    optional_fields: dict[str, Any],
+    *,
+    include_fields: tuple[str, ...] = OPTIONAL_ARCHIVE_TRUTH_FIELDS,
+) -> dict[str, Any] | None:
+    if not optional_fields or not include_fields:
+        return message_meta
+
+    merged = dict(message_meta or {})
+    archive_truth = merged.get("archive_truth")
+    if not isinstance(archive_truth, dict):
+        archive_truth = {}
+
+    for key in include_fields:
+        if key in optional_fields:
+            archive_truth[key] = optional_fields[key]
+    merged["archive_truth"] = archive_truth
+    return merged
+
+
+def _supported_insert_params() -> set[str]:
+    try:
+        return set(inspect.signature(db.insert_message).parameters)
+    except (TypeError, ValueError):
+        return set()
+
+
+def _resolve_optional_writer(hook_names: tuple[str, ...]):
+    for name in hook_names:
+        writer = getattr(db, name, None)
+        if callable(writer):
+            return writer
+    storage = get_storage()
+    for name in hook_names:
+        writer = getattr(storage, name, None)
+        if callable(writer):
+            return writer
+    return None
+
+
+def _call_optional_writer(
+    writer,
+    *,
+    con,
+    message_id: str,
+    payload,
+    payload_kw: str,
+) -> None:
+    attempts = (
+        lambda: writer(con, message_id, payload),
+        lambda: writer(con=con, message_id=message_id, **{payload_kw: payload}),
+        lambda: writer(connection=con, message_id=message_id, **{payload_kw: payload}),
+    )
+    for attempt in attempts:
+        try:
+            attempt()
+            return
+        except TypeError:
+            continue
+    raise TypeError(f"Unable to call optional writer {writer!r} with payload '{payload_kw}'.")
+
+
+def _persist_optional_side_tables(
+    con,
+    message_id: str,
+    canonical_thread_id: str,
+    optional_fields: dict[str, Any],
+) -> None:
+    content_blocks = optional_fields.get("content_blocks")
+    if content_blocks is not None:
+        writer = _resolve_optional_writer((
+            "insert_message_blocks",
+            "upsert_message_blocks",
+            "insert_content_blocks",
+            "insert_message_block",
+        ))
+        if writer:
+            if getattr(writer, "__name__", "") == "insert_message_block":
+                for idx, block in enumerate(content_blocks):
+                    if not isinstance(block, dict):
+                        continue
+                    block_id = str(block.get("block_id") or f"{message_id}:block:{idx}")
+                    db.insert_message_block(
+                        con,
+                        block_id=block_id,
+                        message_id=message_id,
+                        canonical_thread_id=str(
+                            block.get("canonical_thread_id") or block.get("thread_id") or canonical_thread_id
+                        ),
+                        block_index=int(block.get("block_index", idx)),
+                        block_type=str(block.get("block_type") or block.get("type") or "text"),
+                        text=str(block.get("text") or block.get("content") or ""),
+                        source_path=str(block.get("source_path") or optional_fields.get("source_path") or "") or None,
+                        source_bucket=str(block.get("source_bucket") or optional_fields.get("source_bucket") or "") or None,
+                        provenance_json=block.get("provenance_json"),
+                        meta=block.get("meta"),
+                    )
+            else:
+                _call_optional_writer(
+                    writer,
+                    con=con,
+                    message_id=message_id,
+                    payload=content_blocks,
+                    payload_kw="blocks",
+                )
+
+    provenance_refs = optional_fields.get("provenance_refs")
+    if provenance_refs is not None:
+        writer = _resolve_optional_writer((
+            "insert_provenance_refs",
+            "upsert_provenance_refs",
+            "insert_message_provenance_refs",
+            "insert_provenance_ref",
+        ))
+        if writer:
+            if getattr(writer, "__name__", "") == "insert_provenance_ref":
+                for idx, ref in enumerate(provenance_refs):
+                    if not isinstance(ref, dict):
+                        continue
+                    provenance_ref_id = str(ref.get("provenance_ref_id") or f"{message_id}:prov:{idx}")
+                    db.insert_provenance_ref(
+                        con,
+                        provenance_ref_id=provenance_ref_id,
+                        message_id=message_id,
+                        block_id=str(ref.get("block_id") or "") or None,
+                        ref_index=int(ref.get("ref_index", idx)),
+                        source_id=str(ref.get("source_id") or "") or None,
+                        source_thread_id=str(ref.get("source_thread_id") or "") or None,
+                        source_message_id=str(ref.get("source_message_id") or "") or None,
+                        source_path=str(ref.get("source_path") or optional_fields.get("source_path") or "") or None,
+                        source_bucket=str(ref.get("source_bucket") or optional_fields.get("source_bucket") or "") or None,
+                        locator_json=ref.get("locator_json"),
+                        meta=ref.get("meta"),
+                    )
+            else:
+                _call_optional_writer(
+                    writer,
+                    con=con,
+                    message_id=message_id,
+                    payload=provenance_refs,
+                    payload_kw="refs",
+                )
+
+
+def _persist_predicate_projection(
+    con,
+    message_id: str,
+    canonical_thread_id: str,
+    message_meta: dict[str, Any] | None,
+) -> None:
+    if not isinstance(message_meta, dict):
+        return
+    itir_payload = message_meta.get("itir")
+    if not isinstance(itir_payload, dict):
+        return
+    projection = itir_payload.get("predicate_projection")
+    if not isinstance(projection, dict):
+        return
+    writer = getattr(db, "insert_predicate_projection", None)
+    if callable(writer):
+        writer(con, message_id, canonical_thread_id, projection)
 
 
 def _canonical_thread_id_for_messages(
@@ -119,6 +302,7 @@ def ingest_parsed_messages(
 
     inserted = 0
     duplicates = 0
+    insert_params = _supported_insert_params()
     for _tid, thread_messages in tqdm(threads.items(), desc="Importing", file=sys.stderr):
         thread_messages.sort(key=lambda m: m["created_at"])
         canonical_thread_id = _canonical_thread_id_for_messages(
@@ -137,24 +321,45 @@ def ingest_parsed_messages(
                 account_id=account_id,
                 canonical_thread_id=canonical_thread_id,
             )
+            optional_fields = _extract_optional_archive_fields(msg)
             message_meta = _build_message_meta(msg["content"] or "")
-            was_inserted = db.insert_message(
-                con,
-                message_id,
-                canonical_thread_id,
-                platform,
-                account_id,
-                ts_iso,
-                msg["role"] or "",
-                msg["content"] or "",
-                msg.get("thread_title"),
-                source_id,
-                str(msg.get("thread_id") or "") or None,
-                str(msg.get("source_message_id") or "") or None,
-                message_meta,
-            )
+
+            insert_kwargs: dict[str, Any] = {
+                "con": con,
+                "message_id": message_id,
+                "canonical_thread_id": canonical_thread_id,
+                "platform": platform,
+                "account_id": account_id,
+                "ts": ts_iso,
+                "role": msg["role"] or "",
+                "text": msg["content"] or "",
+                "title": msg.get("thread_title"),
+                "source_id": source_id,
+                "source_thread_id": str(msg.get("thread_id") or "") or None,
+                "source_message_id": str(msg.get("source_message_id") or "") or None,
+                "meta": message_meta,
+            }
+
+            direct_optional = ("source_path", "source_bucket", "provenance_json")
+            fallback_fields = [
+                key for key in OPTIONAL_ARCHIVE_TRUTH_FIELDS
+                if key in optional_fields and key not in insert_params
+            ]
+            if fallback_fields:
+                insert_kwargs["meta"] = _legacy_meta_with_archive_truth(
+                    message_meta,
+                    optional_fields,
+                    include_fields=tuple(fallback_fields),
+                )
+            for key in direct_optional:
+                if key in insert_params and key in optional_fields:
+                    insert_kwargs[key] = optional_fields[key]
+
+            was_inserted = db.insert_message(**insert_kwargs)
             if was_inserted:
                 inserted += 1
+                _persist_optional_side_tables(con, message_id, canonical_thread_id, optional_fields)
+                _persist_predicate_projection(con, message_id, canonical_thread_id, insert_kwargs["meta"])
             else:
                 duplicates += 1
         con.commit()

--- a/src/mychatarchive/ingest_bridge.py
+++ b/src/mychatarchive/ingest_bridge.py
@@ -1,0 +1,369 @@
+"""Bridge canonical chat archive rows into MyChatArchive storage.
+
+The bridge treats the canonical archive as read-only source of truth. It does
+not create a new schema in that archive; it imports rows into MyChatArchive's
+normal messages table so embeddings can hang from stable message/thread IDs.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import sqlite3
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from mychatarchive import db
+
+
+CANONICAL_ALIASES: dict[str, tuple[str, ...]] = {
+    "message_id": ("message_id", "id", "source_message_id"),
+    "canonical_thread_id": ("canonical_thread_id", "thread_hash", "conversation_hash"),
+    "source_thread_id": ("source_thread_id", "online_thread_id", "conversation_id", "thread_id"),
+    "source_message_id": ("source_message_id", "upstream_message_id", "message_uuid"),
+    "platform": ("platform", "provider", "source_platform"),
+    "account_id": ("account_id", "account", "workspace", "user_id"),
+    "ts": ("ts", "created_at", "create_time", "timestamp", "time"),
+    "role": ("role", "author_role", "speaker"),
+    "text": ("text", "content", "message", "body"),
+    "title": ("title", "thread_title", "conversation_title"),
+    "source_id": ("source_id", "import_id", "source"),
+    "source_path": ("source_path", "path", "file_path"),
+    "source_bucket": ("source_bucket", "bucket"),
+    "provenance_json": ("provenance_json", "provenance", "metadata_json"),
+    "meta": ("meta", "metadata"),
+}
+
+REQUIRED_FIELDS = ("canonical_thread_id", "ts", "role", "text")
+
+
+@dataclass(frozen=True)
+class BridgeResult:
+    """Summary of a canonical archive import."""
+
+    inserted: int
+    duplicates: int
+    skipped: int
+    source_rows: int
+    canonical_db: str
+    mca_db: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "inserted": self.inserted,
+            "duplicates": self.duplicates,
+            "skipped": self.skipped,
+            "source_rows": self.source_rows,
+            "canonical_db": self.canonical_db,
+            "mca_db": self.mca_db,
+        }
+
+
+def _sha1(value: str) -> str:
+    return hashlib.sha1(value.encode("utf-8", errors="ignore")).hexdigest()
+
+
+def _json_loads(value: Any) -> Any:
+    if value is None or isinstance(value, (dict, list)):
+        return value
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return {"raw": value}
+
+
+def _iso_timestamp(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return (
+            dt.datetime.fromtimestamp(float(value), dt.timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+        )
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        numeric = float(text)
+    except ValueError:
+        normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+        try:
+            parsed = dt.datetime.fromisoformat(normalized)
+        except ValueError:
+            return text
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=dt.timezone.utc)
+        return parsed.astimezone(dt.timezone.utc).replace(microsecond=0).isoformat()
+    return (
+        dt.datetime.fromtimestamp(numeric, dt.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+    )
+
+
+def _table_columns(con: sqlite3.Connection, table: str) -> set[str]:
+    rows = con.execute(f"PRAGMA table_info({table})").fetchall()
+    return {row["name"] for row in rows}
+
+
+def _column_for(field: str, columns: set[str]) -> str | None:
+    for candidate in CANONICAL_ALIASES[field]:
+        if candidate in columns:
+            return candidate
+    return None
+
+
+def _select_rows(
+    con: sqlite3.Connection,
+    columns: set[str],
+    *,
+    limit: int | None,
+) -> Iterable[sqlite3.Row]:
+    selects: list[str] = []
+    for field in CANONICAL_ALIASES:
+        column = _column_for(field, columns)
+        if column:
+            selects.append(f'"{column}" AS "{field}"')
+        else:
+            selects.append(f"NULL AS \"{field}\"")
+
+    order_column = _column_for("ts", columns)
+    sql = f"SELECT {', '.join(selects)} FROM messages"
+    if order_column:
+        sql += f' ORDER BY "canonical_thread_id", "{order_column}", rowid'
+    if limit is not None:
+        sql += " LIMIT ?"
+        return con.execute(sql, (limit,))
+    return con.execute(sql)
+
+
+def validate_canonical_archive(con: sqlite3.Connection) -> None:
+    """Raise ValueError if the source DB cannot provide canonical message rows."""
+    row = con.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'messages'"
+    ).fetchone()
+    if row is None:
+        raise ValueError("Canonical archive DB must contain a messages table.")
+
+    columns = _table_columns(con, "messages")
+    missing = [field for field in REQUIRED_FIELDS if _column_for(field, columns) is None]
+    if missing:
+        raise ValueError(
+            "Canonical archive messages table is missing required field(s): "
+            + ", ".join(missing)
+        )
+
+
+def _bridge_message_id(row: sqlite3.Row) -> str:
+    message_id = str(row["message_id"] or "").strip()
+    if message_id:
+        return message_id
+    parts = [
+        "canonical_bridge",
+        str(row["canonical_thread_id"] or ""),
+        str(row["source_message_id"] or ""),
+        str(row["role"] or ""),
+        str(row["ts"] or ""),
+        str(row["text"] or ""),
+    ]
+    return _sha1("|".join(parts))
+
+
+def _provenance_payload(
+    row: sqlite3.Row,
+    *,
+    canonical_db: Path,
+    source_id: str,
+) -> dict[str, Any]:
+    existing = _json_loads(row["provenance_json"])
+    payload = existing if isinstance(existing, dict) else {}
+    payload.setdefault("bridge", {})
+    payload["bridge"].update(
+        {
+            "kind": "canonical_archive_to_mychatarchive",
+            "canonical_db": str(canonical_db.expanduser()),
+            "source_id": source_id,
+            "canonical_message_id": row["message_id"],
+        }
+    )
+    return payload
+
+
+def _meta_payload(
+    row: sqlite3.Row,
+    *,
+    canonical_db: Path,
+    source_id: str,
+) -> dict[str, Any]:
+    existing = _json_loads(row["meta"])
+    meta = existing if isinstance(existing, dict) else {}
+    meta.setdefault("canonical_bridge", {})
+    meta["canonical_bridge"].update(
+        {
+            "canonical_db": str(canonical_db.expanduser()),
+            "source_id": source_id,
+            "canonical_message_id": row["message_id"],
+            "canonical_thread_id": row["canonical_thread_id"],
+            "source_thread_id": row["source_thread_id"],
+            "source_message_id": row["source_message_id"],
+        }
+    )
+    return meta
+
+
+def import_canonical_archive(
+    canonical_db_path: Path,
+    mca_db_path: Path,
+    *,
+    default_platform: str = "canonical",
+    default_account_id: str = "main",
+    source_id: str | None = None,
+    limit: int | None = None,
+) -> BridgeResult:
+    """Import rows from a canonical chat archive into MyChatArchive.
+
+    Returns counts suitable for JSON CLI wrappers. Re-running is idempotent
+    because the target message_id is deterministic and inserted with
+    ``INSERT OR IGNORE`` by the active storage backend.
+    """
+    canonical_path = Path(canonical_db_path).expanduser()
+    mca_path = Path(mca_db_path).expanduser()
+    bridge_source_id = source_id or f"canonical_archive:{canonical_path.name}"
+
+    source = sqlite3.connect(f"file:{canonical_path.resolve()}?mode=ro", uri=True)
+    source.row_factory = sqlite3.Row
+    try:
+        validate_canonical_archive(source)
+        target = db.get_connection(mca_path)
+        try:
+            db.ensure_schema(target)
+            columns = _table_columns(source, "messages")
+
+            inserted = 0
+            duplicates = 0
+            skipped = 0
+            source_rows = 0
+
+            for row in _select_rows(source, columns, limit=limit):
+                source_rows += 1
+                ts = _iso_timestamp(row["ts"])
+                text = str(row["text"] or "")
+                canonical_thread_id = str(row["canonical_thread_id"] or "").strip()
+                if not ts or not text.strip() or not canonical_thread_id:
+                    skipped += 1
+                    continue
+
+                platform = str(row["platform"] or default_platform)
+                account_id = str(row["account_id"] or default_account_id)
+                message_id = _bridge_message_id(row)
+                source_thread_id = str(row["source_thread_id"] or canonical_thread_id) or None
+                source_message_id = str(row["source_message_id"] or row["message_id"] or "") or None
+
+                was_inserted = db.insert_message(
+                    target,
+                    message_id=message_id,
+                    canonical_thread_id=canonical_thread_id,
+                    platform=platform,
+                    account_id=account_id,
+                    ts=ts,
+                    role=str(row["role"] or ""),
+                    text=text,
+                    title=row["title"],
+                    source_id=str(row["source_id"] or bridge_source_id),
+                    source_thread_id=source_thread_id,
+                    source_message_id=source_message_id,
+                    source_path=row["source_path"],
+                    source_bucket=row["source_bucket"],
+                    provenance_json=_provenance_payload(
+                        row, canonical_db=canonical_path, source_id=bridge_source_id
+                    ),
+                    meta=_meta_payload(
+                        row, canonical_db=canonical_path, source_id=bridge_source_id
+                    ),
+                )
+                if was_inserted:
+                    inserted += 1
+                else:
+                    duplicates += 1
+
+            target.commit()
+            return BridgeResult(
+                inserted=inserted,
+                duplicates=duplicates,
+                skipped=skipped,
+                source_rows=source_rows,
+                canonical_db=str(canonical_path),
+                mca_db=str(mca_path),
+            )
+        finally:
+            target.close()
+    finally:
+        source.close()
+
+
+def _dry_run_result(canonical_db_path: Path, mca_db_path: Path, *, limit: int | None) -> BridgeResult:
+    canonical_path = Path(canonical_db_path).expanduser()
+    mca_path = Path(mca_db_path).expanduser()
+    source = sqlite3.connect(f"file:{canonical_path.resolve()}?mode=ro", uri=True)
+    source.row_factory = sqlite3.Row
+    try:
+        validate_canonical_archive(source)
+        columns = _table_columns(source, "messages")
+        source_rows = 0
+        skipped = 0
+        for row in _select_rows(source, columns, limit=limit):
+            source_rows += 1
+            ts = _iso_timestamp(row["ts"])
+            text = str(row["text"] or "")
+            canonical_thread_id = str(row["canonical_thread_id"] or "").strip()
+            if not ts or not text.strip() or not canonical_thread_id:
+                skipped += 1
+        return BridgeResult(
+            inserted=0,
+            duplicates=0,
+            skipped=skipped,
+            source_rows=source_rows,
+            canonical_db=str(canonical_path),
+            mca_db=str(mca_path),
+        )
+    finally:
+        source.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Import canonical archive rows into MyChatArchive.")
+    parser.add_argument("--canonical-db", required=True)
+    parser.add_argument("--mca-db", required=True)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--json", action="store_true", help="Emit JSON output.")
+    args = parser.parse_args()
+
+    if args.dry_run:
+        result = _dry_run_result(Path(args.canonical_db), Path(args.mca_db), limit=args.limit)
+    else:
+        result = import_canonical_archive(
+            Path(args.canonical_db),
+            Path(args.mca_db),
+            limit=args.limit,
+        )
+    payload = result.as_dict()
+    if args.dry_run:
+        payload["dry_run"] = True
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mychatarchive/itir.py
+++ b/src/mychatarchive/itir.py
@@ -1,0 +1,150 @@
+"""Required ITIR/SensibLaw enrichment for imported messages.
+
+MyChatArchive should not silently ingest messages without the shared-reducer
+normalization payload. Imports fail fast when the local ITIR surface is
+unavailable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from functools import lru_cache
+import importlib
+from pathlib import Path
+import sys
+from typing import Any
+
+from mychatarchive.config import get_itir_paths
+
+_SHARED_REDUCER_MODULE = "sensiblaw.interfaces.shared_reducer"
+
+
+class ITIREnrichment:
+    """Wrapper around the supported SensibLaw shared reducer surface."""
+
+    def __init__(self, root: Path, reducer_module):
+        self.root = root
+        self.reducer_module = reducer_module
+
+    def enrich_text(self, text: str) -> dict[str, Any] | None:
+        text = (text or "").strip()
+        if not text:
+            return None
+
+        reducer = self.reducer_module
+        payload: dict[str, Any] = {
+            "surface": _SHARED_REDUCER_MODULE,
+            "source_root": str(self.root),
+            "tokenizer_profile_receipt": reducer.get_canonical_tokenizer_profile_receipt(),
+            "token_spans": [
+                {"text": token, "start": start, "end": end}
+                for token, start, end in reducer.tokenize_canonical_with_spans(text)
+            ],
+            "lexeme_refs": reducer.collect_canonical_lexeme_refs(text),
+            "structure_occurrences": [
+                _to_plain_dict(occ)
+                for occ in reducer.collect_canonical_structure_occurrences(text)
+            ],
+        }
+
+        try:
+            payload["relational_bundle"] = reducer.collect_canonical_relational_bundle(text)
+        except Exception as exc:
+            payload["relational_bundle_error"] = type(exc).__name__
+
+        return payload
+
+
+def _to_plain_dict(value: Any) -> Any:
+    if is_dataclass(value):
+        return asdict(value)
+    if isinstance(value, dict):
+        return {key: _to_plain_dict(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_plain_dict(item) for item in value]
+    return value
+
+
+def _candidate_sys_paths(root: Path) -> list[Path]:
+    candidates: list[Path] = []
+    if root.name == "src":
+        candidates.append(root.parent)
+        candidates.append(root)
+    else:
+        candidates.append(root)
+        src_dir = root / "src"
+        if src_dir.is_dir():
+            candidates.append(src_dir)
+    return [path for path in candidates if path.exists()]
+
+
+def _import_shared_reducer(root: Path):
+    original_sys_path = list(sys.path)
+    for candidate in reversed(_candidate_sys_paths(root)):
+        candidate_str = str(candidate)
+        if candidate_str not in sys.path:
+            sys.path.insert(0, candidate_str)
+    try:
+        return importlib.import_module(_SHARED_REDUCER_MODULE)
+    finally:
+        sys.path[:] = original_sys_path
+
+
+def _normalize_candidate_path(path: Path) -> Path:
+    path = path.expanduser().resolve()
+    if path.name == "shared_reducer.py":
+        return path.parent.parent.parent
+    if path.name == "interfaces":
+        return path.parent.parent
+    if path.name == "sensiblaw":
+        return path.parent
+    return path
+
+
+def _iter_candidate_roots() -> tuple[Path, ...]:
+    configured = tuple(_normalize_candidate_path(path) for path in get_itir_paths())
+    if configured:
+        return configured
+
+    repo_root = Path(__file__).resolve().parents[2]
+    defaults = (
+        repo_root.parent / "ITIR-suite" / "SensibLaw",
+        Path.home() / "Documents" / "code" / "ITIR-suite" / "SensibLaw",
+    )
+    return tuple(path for path in defaults if path.exists())
+
+
+@lru_cache(maxsize=8)
+def _load_enrichment(root_value: str) -> ITIREnrichment | None:
+    root = Path(root_value)
+    if not root.exists():
+        return None
+    try:
+        reducer_module = _import_shared_reducer(root)
+    except Exception:
+        return None
+    return ITIREnrichment(root=root, reducer_module=reducer_module)
+
+
+def get_itir_enrichment() -> ITIREnrichment | None:
+    for root in _iter_candidate_roots():
+        enrichment = _load_enrichment(str(root))
+        if enrichment is not None:
+            return enrichment
+    return None
+
+
+def enrich_text(text: str) -> dict[str, Any] | None:
+    text = (text or "").strip()
+    if not text:
+        return None
+
+    enrichment = get_itir_enrichment()
+    if enrichment is None:
+        roots = ", ".join(str(path) for path in _iter_candidate_roots()) or "<none found>"
+        raise RuntimeError(
+            "Required ITIR shared reducer is unavailable. "
+            f"Checked roots: {roots}. Configure config.itir.paths or "
+            "MYCHATARCHIVE_ITIR_PATHS."
+        )
+    return enrichment.enrich_text(text)

--- a/src/mychatarchive/itir.py
+++ b/src/mychatarchive/itir.py
@@ -15,6 +15,7 @@ import sys
 from typing import Any
 
 from mychatarchive.config import get_itir_paths
+from mychatarchive.itir_projection import build_predicate_projection
 
 _SHARED_REDUCER_MODULE = "sensiblaw.interfaces.shared_reducer"
 
@@ -51,6 +52,11 @@ class ITIREnrichment:
             payload["relational_bundle"] = reducer.collect_canonical_relational_bundle(text)
         except Exception as exc:
             payload["relational_bundle_error"] = type(exc).__name__
+
+        try:
+            payload["predicate_projection"] = build_predicate_projection(text, reducer)
+        except Exception as exc:
+            payload["predicate_projection_error"] = type(exc).__name__
 
         return payload
 

--- a/src/mychatarchive/itir_projection.py
+++ b/src/mychatarchive/itir_projection.py
@@ -1,0 +1,257 @@
+"""Bounded ITIR predicate projection helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, is_dataclass
+import re
+from typing import Any
+
+_PROJECTION_VERSION = "itir_predicate_projection_v1"
+_MAX_PREDICATES = 64
+_MAX_ROLES_PER_PREDICATE = 12
+_MAX_PROVENANCE_REFS = 16
+_MAX_SPAN_REFS = 16
+_MAX_INDEX_KEYS = 128
+_MAX_INDEX_REFS_PER_KEY = 32
+
+_SPAN_REF_RE = re.compile(r"^[a-z_]+:(\d+)-(\d+)$")
+
+
+def build_predicate_projection(text: str, reducer_module) -> dict[str, Any]:
+    """Build a deterministic, serializable, bounded predicate projection."""
+    predicate_atoms = _collect_predicate_atoms(text, reducer_module)
+    ref_map = _build_ref_map(predicate_atoms, reducer_module)
+    projected_items = sorted(ref_map.items(), key=lambda item: str(item[0]))[:_MAX_PREDICATES]
+
+    predicates = [_serialize_predicate(ref, atom) for ref, atom in projected_items]
+    index = _build_index([atom for _, atom in projected_items], reducer_module)
+
+    return {
+        "version": _PROJECTION_VERSION,
+        "limits": {
+            "max_predicates": _MAX_PREDICATES,
+            "max_roles_per_predicate": _MAX_ROLES_PER_PREDICATE,
+            "max_provenance_refs": _MAX_PROVENANCE_REFS,
+            "max_span_refs": _MAX_SPAN_REFS,
+            "max_index_keys": _MAX_INDEX_KEYS,
+            "max_index_refs_per_key": _MAX_INDEX_REFS_PER_KEY,
+        },
+        "counts": {
+            "predicates_total": len(ref_map),
+            "predicates_projected": len(predicates),
+            "predicates_truncated": len(ref_map) > len(predicates),
+        },
+        "predicates": predicates,
+        "index": index,
+    }
+
+
+def _collect_predicate_atoms(text: str, reducer_module) -> list[Any]:
+    text = (text or "").strip()
+    if not text:
+        return []
+    if hasattr(reducer_module, "collect_canonical_predicate_atoms"):
+        collected = reducer_module.collect_canonical_predicate_atoms(text)
+        return list(collected or [])
+    if hasattr(reducer_module, "collect_canonical_predicate_pnfs"):
+        collected = reducer_module.collect_canonical_predicate_pnfs(text)
+        return list(collected or [])
+    raise RuntimeError("missing predicate collection surface")
+
+
+def _build_ref_map(predicate_atoms: Iterable[Any], reducer_module) -> dict[str, Any]:
+    if hasattr(reducer_module, "build_predicate_ref_map"):
+        raw = reducer_module.build_predicate_ref_map(predicate_atoms)
+        if isinstance(raw, Mapping):
+            return {str(key): value for key, value in raw.items()}
+    fallback: dict[str, Any] = {}
+    for index, atom in enumerate(predicate_atoms):
+        atom_payload = _to_plain_dict(atom)
+        atom_id = atom_payload.get("atom_id") or atom_payload.get("id")
+        fallback[str(atom_id or f"pnf:{index}")] = atom
+    return fallback
+
+
+def _build_index(predicate_atoms: list[Any], reducer_module) -> dict[str, Any]:
+    if hasattr(reducer_module, "build_predicate_index"):
+        index_obj = reducer_module.build_predicate_index(predicate_atoms)
+        return _serialize_index(index_obj)
+    return _serialize_index(_fallback_index(predicate_atoms))
+
+
+def _fallback_index(predicate_atoms: list[Any]) -> dict[str, Any]:
+    by_structural_sig: dict[str, list[str]] = {}
+    by_role_slot: dict[str, list[str]] = {}
+    by_argval: dict[str, list[str]] = {}
+    by_role_arg: dict[str, list[str]] = {}
+
+    for index, atom in enumerate(predicate_atoms):
+        payload = _to_plain_dict(atom)
+        ref = str(payload.get("atom_id") or payload.get("id") or f"pnf:{index}")
+        sig = str(payload.get("structural_signature") or payload.get("predicate") or "")
+        if sig:
+            by_structural_sig.setdefault(sig, []).append(ref)
+        roles = payload.get("roles")
+        if not isinstance(roles, Mapping):
+            continue
+        for role_name, role_value in roles.items():
+            role_key = str(role_name)
+            by_role_slot.setdefault(role_key, []).append(ref)
+            role_payload = _to_plain_dict(role_value)
+            value = str(role_payload.get("value", "")).strip()
+            if not value:
+                continue
+            by_argval.setdefault(value, []).append(ref)
+            by_role_arg.setdefault(f"{role_key}|{value}", []).append(ref)
+
+    return {
+        "by_structural_sig": by_structural_sig,
+        "by_role_slot": by_role_slot,
+        "by_argval": by_argval,
+        "by_role_arg": by_role_arg,
+    }
+
+
+def _serialize_predicate(ref: str, atom: Any) -> dict[str, Any]:
+    payload = _to_plain_dict(atom)
+    roles = _serialize_roles(payload.get("roles"))
+    provenance_refs = _normalize_refs(payload.get("provenance"))
+    span_refs = _extract_span_refs(
+        [*provenance_refs, *(ref_value for role in roles for ref_value in role["provenance_refs"])]
+    )
+
+    qualifiers = _to_plain_dict(payload.get("qualifiers"))
+    wrapper = _to_plain_dict(payload.get("wrapper"))
+
+    predicate_payload: dict[str, Any] = {
+        "ref": ref,
+        "atom_id": _optional_str(payload.get("atom_id") or payload.get("id")),
+        "predicate": str(payload.get("predicate", "")),
+        "structural_signature": str(payload.get("structural_signature") or payload.get("predicate") or ""),
+        "roles": roles,
+        "polarity": str(qualifiers.get("polarity") or "positive"),
+        "modality": _optional_str(qualifiers.get("modality")),
+        "provenance_refs": provenance_refs,
+        "source_spans": span_refs,
+        "wrapper": {
+            "status": _optional_str(wrapper.get("status")),
+            "evidence_only": bool(wrapper.get("evidence_only", True)),
+        },
+    }
+    domain = _optional_str(payload.get("domain"))
+    if domain is not None:
+        predicate_payload["domain"] = domain
+    return predicate_payload
+
+
+def _serialize_roles(raw_roles: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw_roles, Mapping):
+        return []
+    roles: list[dict[str, Any]] = []
+    for role_name in sorted(str(key) for key in raw_roles):
+        role_payload = _to_plain_dict(raw_roles.get(role_name))
+        value = _optional_str(role_payload.get("value"))
+        if value is None:
+            continue
+        role_entry: dict[str, Any] = {
+            "name": role_name,
+            "value": value,
+            "status": str(role_payload.get("status") or "bound"),
+            "entity_type": _optional_str(role_payload.get("entity_type")),
+            "cardinality": str(role_payload.get("cardinality") or "single"),
+            "members": _normalize_refs(role_payload.get("members")),
+            "provenance_refs": _normalize_refs(role_payload.get("provenance")),
+        }
+        roles.append(role_entry)
+        if len(roles) >= _MAX_ROLES_PER_PREDICATE:
+            break
+    return roles
+
+
+def _serialize_index(index_obj: Any) -> dict[str, Any]:
+    payload = _to_plain_dict(index_obj)
+    return {
+        "by_structural_signature": _normalize_index_mapping(payload.get("by_structural_sig")),
+        "by_role": _normalize_index_mapping(payload.get("by_role_slot")),
+        "by_argument": _normalize_index_mapping(payload.get("by_argval")),
+        "by_role_argument": _normalize_index_mapping(payload.get("by_role_arg"), normalize_tuple_keys=True),
+    }
+
+
+def _normalize_index_mapping(raw: Any, *, normalize_tuple_keys: bool = False) -> dict[str, list[str]]:
+    if not isinstance(raw, Mapping):
+        return {}
+    normalized: dict[str, list[str]] = {}
+    for key in sorted(raw, key=lambda value: str(value)):
+        refs = _normalize_refs(raw.get(key), max_items=_MAX_INDEX_REFS_PER_KEY)
+        if not refs:
+            continue
+        if normalize_tuple_keys and isinstance(key, tuple) and len(key) == 2:
+            normalized_key = f"{key[0]}|{key[1]}"
+        else:
+            normalized_key = str(key)
+        normalized[normalized_key] = refs
+        if len(normalized) >= _MAX_INDEX_KEYS:
+            break
+    return normalized
+
+
+def _normalize_refs(raw: Any, *, max_items: int = _MAX_PROVENANCE_REFS) -> list[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [raw]
+    if not isinstance(raw, Iterable):
+        return [str(raw)]
+    refs: list[str] = []
+    seen: set[str] = set()
+    for item in raw:
+        if item is None:
+            continue
+        value = str(item).strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        refs.append(value)
+        if len(refs) >= max_items:
+            break
+    return refs
+
+
+def _extract_span_refs(refs: list[str]) -> list[dict[str, Any]]:
+    spans: list[dict[str, Any]] = []
+    seen: set[tuple[int, int]] = set()
+    for ref in refs:
+        match = _SPAN_REF_RE.match(ref)
+        if not match:
+            continue
+        start = int(match.group(1))
+        end = int(match.group(2))
+        key = (start, end)
+        if key in seen:
+            continue
+        seen.add(key)
+        spans.append({"start": start, "end": end, "ref": ref})
+        if len(spans) >= _MAX_SPAN_REFS:
+            break
+    return spans
+
+
+def _to_plain_dict(value: Any) -> Any:
+    if hasattr(value, "to_dict") and callable(value.to_dict):
+        return _to_plain_dict(value.to_dict())
+    if is_dataclass(value):
+        return asdict(value)
+    if isinstance(value, Mapping):
+        return {key: _to_plain_dict(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_plain_dict(item) for item in value]
+    return value
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/src/mychatarchive/itir_residuals.py
+++ b/src/mychatarchive/itir_residuals.py
@@ -1,0 +1,101 @@
+"""Bounded residual-style comparison over serialized predicate projections."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def summarize_projection_residual(
+    query_projection: Mapping[str, Any] | None,
+    candidate_projection: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if not isinstance(query_projection, Mapping) or not isinstance(candidate_projection, Mapping):
+        return {
+            "available": False,
+            "shared_predicates": [],
+            "contradictions": [],
+            "unresolved_predicates": [],
+            "shared_role_arguments": [],
+            "score": 0.0,
+        }
+
+    query_preds = _index_predicates(query_projection)
+    candidate_preds = _index_predicates(candidate_projection)
+
+    query_sigs = set(query_preds)
+    candidate_sigs = set(candidate_preds)
+    shared = sorted(query_sigs & candidate_sigs)
+    unresolved = sorted(query_sigs - candidate_sigs)
+
+    contradictions: list[str] = []
+    shared_role_arguments: list[str] = []
+    for sig in shared:
+        query_item = query_preds[sig]
+        candidate_item = candidate_preds[sig]
+        if query_item["polarity"] and candidate_item["polarity"] and query_item["polarity"] != candidate_item["polarity"]:
+            contradictions.append(sig)
+        shared_role_arguments.extend(sorted(query_item["role_args"] & candidate_item["role_args"]))
+
+    shared_role_arguments = sorted(set(shared_role_arguments))
+    overlap_score = (len(shared) / len(query_sigs)) if query_sigs else 0.0
+    contradiction_penalty = min(len(contradictions) * 0.25, 1.0)
+    role_bonus = min(len(shared_role_arguments) * 0.05, 0.25)
+    score = max(0.0, min(1.0, overlap_score + role_bonus - contradiction_penalty))
+
+    return {
+        "available": True,
+        "shared_predicates": shared,
+        "contradictions": contradictions,
+        "unresolved_predicates": unresolved,
+        "shared_role_arguments": shared_role_arguments,
+        "score": round(score, 4),
+    }
+
+
+def extract_projection_terms(projection: Mapping[str, Any] | None) -> dict[str, list[str]]:
+    """Return normalized lookup terms for archive-level predicate retrieval."""
+    if not isinstance(projection, Mapping):
+        return {"signatures": [], "role_arguments": []}
+
+    indexed = _index_predicates(projection)
+    signatures = sorted(indexed)
+    role_arguments: set[str] = set()
+    for item in indexed.values():
+        role_arguments.update(item["role_args"])
+    return {
+        "signatures": signatures,
+        "role_arguments": sorted(role_arguments),
+    }
+
+
+def _index_predicates(projection: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    predicates = projection.get("predicates")
+    if not isinstance(predicates, list):
+        return {}
+    indexed: dict[str, dict[str, Any]] = {}
+    for pred in predicates:
+        if not isinstance(pred, Mapping):
+            continue
+        sig = str(pred.get("structural_signature") or pred.get("predicate") or "").strip()
+        if not sig:
+            continue
+        indexed[sig] = {
+            "polarity": str(pred.get("polarity") or "").strip() or None,
+            "role_args": _role_args(pred.get("roles")),
+        }
+    return indexed
+
+
+def _role_args(roles: Any) -> set[str]:
+    if not isinstance(roles, list):
+        return set()
+    result: set[str] = set()
+    for role in roles:
+        if not isinstance(role, Mapping):
+            continue
+        name = str(role.get("name") or "").strip()
+        value = str(role.get("value") or "").strip()
+        if name and value:
+            result.add(f"{name}|{value}")
+    return result

--- a/src/mychatarchive/live.py
+++ b/src/mychatarchive/live.py
@@ -1,0 +1,364 @@
+"""Live source resolution and ChatGPT provider fetch helpers."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import re
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from mychatarchive.config import get_re_gpt_roots
+
+_ONLINE_THREAD_ID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+_ONLINE_THREAD_ID_FROM_URL_RE = re.compile(
+    r"/c/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+)
+
+
+@dataclass
+class DbResolution:
+    match_type: str
+    canonical_thread_id: str
+    source_thread_id: str | None
+    title: str
+    matched_thread_count: int
+    latest_ts: str | None
+
+
+def looks_like_online_thread_id(selector: str) -> bool:
+    return bool(_ONLINE_THREAD_ID_RE.fullmatch(selector.strip()))
+
+
+def looks_like_canonical_thread_id(selector: str) -> bool:
+    return bool(re.fullmatch(r"[0-9a-f]{40}", selector.strip().lower()))
+
+
+def extract_online_thread_id_from_url(selector: str) -> str | None:
+    match = _ONLINE_THREAD_ID_FROM_URL_RE.search(selector)
+    if match:
+        return match.group(1)
+    return None
+
+
+def normalize_live_selector(selector: str) -> str:
+    candidate = (selector or "").strip()
+    online_id = extract_online_thread_id_from_url(candidate)
+    if online_id:
+        return online_id
+    return candidate
+
+
+def _fts_query(selector: str) -> str | None:
+    tokens = re.findall(r"[A-Za-z0-9_]{2,}", selector.lower())
+    if not tokens:
+        return None
+    seen: set[str] = set()
+    uniq: list[str] = []
+    for token in tokens:
+        if token in seen:
+            continue
+        seen.add(token)
+        uniq.append(token)
+    if not uniq:
+        return None
+    return " OR ".join(f"{token}*" for token in uniq)
+
+
+def resolve_selector_from_db(db_path: Path, selector: str) -> DbResolution | None:
+    if not db_path.exists():
+        return None
+
+    con = sqlite3.connect(str(db_path))
+    try:
+        cur = con.cursor()
+        cols = {
+            row[1]
+            for row in cur.execute("PRAGMA table_info(messages)").fetchall()
+        }
+        if not cols:
+            return None
+        normalized = normalize_live_selector(selector)
+
+        if "source_thread_id" in cols:
+            row = cur.execute(
+                """
+                SELECT canonical_thread_id, source_thread_id, COALESCE(NULLIF(title, ''), '(no title)'), MAX(ts)
+                FROM messages
+                WHERE LOWER(source_thread_id) = LOWER(?)
+                GROUP BY canonical_thread_id, source_thread_id, title
+                ORDER BY MAX(ts) DESC
+                LIMIT 1
+                """,
+                (normalized,),
+            ).fetchone()
+            if row:
+                return DbResolution("source_thread_id_exact", row[0], row[1], row[2], 1, row[3])
+
+        if looks_like_canonical_thread_id(normalized):
+            row = cur.execute(
+                """
+                SELECT canonical_thread_id, source_thread_id, COALESCE(NULLIF(title, ''), '(no title)'), MAX(ts)
+                FROM messages
+                WHERE LOWER(canonical_thread_id) = LOWER(?)
+                GROUP BY canonical_thread_id, source_thread_id, title
+                ORDER BY MAX(ts) DESC
+                LIMIT 1
+                """,
+                (normalized,),
+            ).fetchone()
+            if row:
+                return DbResolution("canonical_thread_id_exact", row[0], row[1], row[2], 1, row[3])
+
+        row = cur.execute(
+            """
+            SELECT canonical_thread_id, source_thread_id, COALESCE(NULLIF(title, ''), '(no title)'), MAX(ts)
+            FROM messages
+            WHERE LOWER(title) = LOWER(?)
+            GROUP BY canonical_thread_id, source_thread_id, title
+            ORDER BY MAX(ts) DESC
+            LIMIT 1
+            """,
+            (normalized,),
+        ).fetchone()
+        if row:
+            matched = cur.execute(
+                "SELECT COUNT(DISTINCT canonical_thread_id) FROM messages WHERE LOWER(title) = LOWER(?)",
+                (normalized,),
+            ).fetchone()[0]
+            return DbResolution("title_exact", row[0], row[1], row[2], int(matched or 0), row[3])
+
+        if len(normalized) >= 3:
+            like = f"%{normalized.lower()}%"
+            row = cur.execute(
+                """
+                SELECT canonical_thread_id, source_thread_id, COALESCE(NULLIF(title, ''), '(no title)'), MAX(ts)
+                FROM messages
+                WHERE LOWER(title) LIKE ?
+                GROUP BY canonical_thread_id, source_thread_id, title
+                ORDER BY MAX(ts) DESC
+                LIMIT 1
+                """,
+                (like,),
+            ).fetchone()
+            if row:
+                matched = cur.execute(
+                    "SELECT COUNT(DISTINCT canonical_thread_id) FROM messages WHERE LOWER(title) LIKE ?",
+                    (like,),
+                ).fetchone()[0]
+                return DbResolution("title_contains", row[0], row[1], row[2], int(matched or 0), row[3])
+
+        if not looks_like_online_thread_id(normalized):
+            fts_query = _fts_query(normalized)
+            table_names = {
+                row[0]
+                for row in cur.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('messages_fts', 'messages_fts_docids')"
+                ).fetchall()
+            }
+            if fts_query and {"messages_fts", "messages_fts_docids"} <= table_names:
+                row = cur.execute(
+                    """
+                    SELECT m.canonical_thread_id, m.source_thread_id,
+                           COALESCE(NULLIF(m.title, ''), '(no title)') AS title,
+                           MAX(m.ts) AS latest_ts,
+                           COUNT(*) AS hit_count
+                    FROM messages_fts f
+                    JOIN messages_fts_docids d ON f.rowid = d.rowid
+                    JOIN messages m ON m.message_id = d.message_id
+                    WHERE messages_fts MATCH ?
+                    GROUP BY m.canonical_thread_id, m.source_thread_id, title
+                    ORDER BY hit_count DESC, latest_ts DESC
+                    LIMIT 1
+                    """,
+                    (fts_query,),
+                ).fetchone()
+                if row:
+                    matched = cur.execute(
+                        """
+                        SELECT COUNT(*) FROM (
+                            SELECT DISTINCT m.canonical_thread_id
+                            FROM messages_fts f
+                            JOIN messages_fts_docids d ON f.rowid = d.rowid
+                            JOIN messages m ON m.message_id = d.message_id
+                            WHERE messages_fts MATCH ?
+                        )
+                        """,
+                        (fts_query,),
+                    ).fetchone()[0]
+                    return DbResolution("fts_candidate", row[0], row[1], row[2], int(matched or 0), row[3])
+        return None
+    finally:
+        con.close()
+
+
+def choose_live_selector(db_path: Path, selector: str) -> tuple[str, dict[str, Any]]:
+    normalized = normalize_live_selector(selector)
+    resolution = resolve_selector_from_db(db_path, normalized)
+    if looks_like_online_thread_id(normalized):
+        return normalized, {"resolution": "selector_online_thread_id"}
+    if resolution and resolution.source_thread_id and resolution.matched_thread_count == 1:
+        return resolution.source_thread_id, {
+            "resolution": resolution.match_type,
+            "canonical_thread_id": resolution.canonical_thread_id,
+            "title": resolution.title,
+        }
+    return normalized, {
+        "resolution": resolution.match_type if resolution else "provider_fallback",
+        "canonical_thread_id": resolution.canonical_thread_id if resolution else None,
+        "title": resolution.title if resolution else None,
+        "matched_thread_count": resolution.matched_thread_count if resolution else 0,
+    }
+
+
+def load_session_token() -> str | None:
+    env_token = os.environ.get("CHATGPT_SESSION_TOKEN", "").strip()
+    if env_token:
+        return env_token
+    session_file = Path.home() / ".chatgpt_session"
+    if session_file.exists():
+        lines = session_file.read_text(encoding="utf-8", errors="ignore").splitlines()
+        if lines and lines[0].strip():
+            return lines[0].strip()
+    return None
+
+
+def resolve_live_provider_root() -> Path:
+    for root in get_re_gpt_roots():
+        if (root / "re_gpt").is_dir():
+            return root
+    raise RuntimeError(
+        "No reverse-engineered-chatgpt checkout found. Configure live.re_gpt_paths "
+        "or MYCHATARCHIVE_RE_GPT_PATHS."
+    )
+
+
+def _load_re_gpt_modules(root: Path):
+    original_sys_path = list(sys.path)
+    try:
+        root_str = str(root)
+        if root_str not in sys.path:
+            sys.path.insert(0, root_str)
+        sync = importlib.import_module("re_gpt.sync_chatgpt")
+        return sync.SyncChatGPT
+    finally:
+        sys.path[:] = original_sys_path
+
+
+def _resolve_chatgpt_selector(chatgpt, selector: str) -> tuple[str, str | None, str]:
+    normalized = normalize_live_selector(selector)
+    if looks_like_online_thread_id(normalized):
+        return normalized, None, "online_thread_id"
+
+    target = normalized.lower()
+    contains_match: tuple[str, str | None, str] | None = None
+    offset = 0
+    limit = 100
+    while True:
+        page = chatgpt.list_conversations_page(offset=offset, limit=limit)
+        items = page.get("items", []) if isinstance(page, dict) else []
+        if not items:
+            break
+        for item in items:
+            title = str(item.get("title") or "").strip()
+            conversation_id = str(item.get("id") or "").strip()
+            if not title or not conversation_id:
+                continue
+            lowered = title.lower()
+            if lowered == target:
+                return conversation_id, title, "title_exact"
+            if target in lowered and contains_match is None:
+                contains_match = (conversation_id, title, "title_contains")
+        offset += len(items)
+        if len(items) < limit:
+            break
+    if contains_match:
+        return contains_match
+    raise RuntimeError(f"Unable to resolve live selector: {selector}")
+
+
+def _convert_chat_payload(chat: dict[str, Any]) -> list[dict[str, Any]]:
+    mapping = chat.get("mapping")
+    title = str(chat.get("title") or "")
+    conversation_id = str(chat.get("conversation_id") or chat.get("id") or "").strip()
+    parsed: list[dict[str, Any]] = []
+    if not isinstance(mapping, dict):
+        return parsed
+
+    for node_id, node in mapping.items():
+        if not isinstance(node, dict):
+            continue
+        message = node.get("message")
+        if not isinstance(message, dict):
+            continue
+        author_info = message.get("author") or {}
+        role = str(author_info.get("role") or "")
+        content_info = message.get("content") or {}
+        raw_parts = content_info.get("parts") or []
+        parts: list[str] = []
+        if isinstance(raw_parts, list):
+            for part in raw_parts:
+                if isinstance(part, str) and part.strip():
+                    parts.append(part.strip())
+                elif isinstance(part, dict):
+                    for key in ("text", "content", "title"):
+                        value = part.get(key)
+                        if value:
+                            parts.append(str(value).strip())
+                            break
+        if not parts:
+            continue
+        created_at = message.get("create_time") or message.get("update_time") or 0
+        try:
+            created_at = float(created_at)
+        except (TypeError, ValueError):
+            created_at = 0.0
+        parsed.append(
+            {
+                "thread_id": conversation_id,
+                "thread_title": title,
+                "role": role,
+                "content": "\n".join(parts),
+                "created_at": created_at,
+                "source_message_id": str(message.get("id") or node_id or ""),
+            }
+        )
+
+    parsed.sort(key=lambda item: item["created_at"])
+    for idx, message in enumerate(parsed):
+        if not message.get("source_message_id"):
+            message["source_message_id"] = f"idx:{idx}"
+    return parsed
+
+
+def fetch_live_messages(provider: str, selector: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    provider_name = (provider or "chatgpt").strip().lower()
+    if provider_name != "chatgpt":
+        raise RuntimeError(f"Unsupported live provider: {provider}")
+
+    root = resolve_live_provider_root()
+    session_token = load_session_token()
+    if not session_token:
+        raise RuntimeError(
+            "No ChatGPT session token found. Set CHATGPT_SESSION_TOKEN or create ~/.chatgpt_session."
+        )
+
+    SyncChatGPT = _load_re_gpt_modules(root)
+    with SyncChatGPT(session_token=session_token) as chatgpt:
+        conversation_id, title, provider_resolution = _resolve_chatgpt_selector(chatgpt, selector)
+        chat = chatgpt.fetch_conversation(conversation_id)
+    messages = _convert_chat_payload(chat)
+    return messages, {
+        "provider": provider_name,
+        "provider_root": str(root),
+        "selector": selector,
+        "resolved_selector": conversation_id,
+        "provider_resolution": provider_resolution,
+        "title": title or chat.get("title"),
+        "fetched_at": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
+    }

--- a/src/mychatarchive/mcp/server.py
+++ b/src/mychatarchive/mcp/server.py
@@ -18,6 +18,9 @@ from mcp.server.fastmcp import FastMCP
 
 from mychatarchive import db
 from mychatarchive.config import get_db_path
+from mychatarchive.itir import enrich_text as enrich_text_with_itir
+from mychatarchive.itir_residuals import extract_projection_terms
+from mychatarchive.retrieval_explain import build_provenance_ranked_chunk_results
 
 # Quiet MCP SDK INFO logs (they go to stderr and show as [error] in Cursor's MCP panel)
 logging.getLogger("mcp").setLevel(logging.WARNING)
@@ -145,6 +148,113 @@ def search_brain(
             })
 
     out = {"query": query, "count": len(output), "results": output, **_current_datetime_json()}
+    return json.dumps(out, indent=2)
+
+
+@mcp.tool()
+def search_brain_governed(
+    query: str,
+    limit: int = 10,
+    platform: str | None = None,
+    hours_back: int | None = None,
+    since: str | None = None,
+    sort_by_time: bool = False,
+    group: str | None = None,
+    rerank_by_governance: bool = True,
+    governance_weight: float = 0.30,
+) -> str:
+    """Semantic retrieval with provenance/governance-aware explanation and ranking.
+
+    Starts from semantic vector candidates, then computes governance signals from
+    provenance lineage, source metadata, structured blocks/refs, and ITIR metadata.
+
+    Args:
+        query: Natural-language query for semantic retrieval
+        limit: Maximum number of results to return
+        platform: Optional platform filter (comma-separated values supported)
+        hours_back: Only include messages from the last N hours
+        since: Only include messages from this date (YYYY-MM-DD)
+        sort_by_time: If true, semantic candidate set is first sorted by time
+        group: Filter to a user-curated thread group
+        rerank_by_governance: If true, blend semantic + governance scores for ranking
+        governance_weight: Blend weight for governance in [0, 1] (default 0.30)
+    """
+    con = _get_con()
+    embedding = _lazy_embed(query)
+    platforms = [p.strip() for p in platform.split(",")] if platform else None
+    group_thread_ids = _resolve_group_thread_ids(con, group)
+
+    cutoff_iso = None
+    if hours_back is not None:
+        cutoff_iso = (
+            datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(hours=hours_back)
+        ).isoformat()
+    elif since:
+        try:
+            dt = datetime.datetime.strptime(since, "%Y-%m-%d")
+            cutoff_iso = dt.replace(tzinfo=datetime.timezone.utc).isoformat()
+        except ValueError:
+            return json.dumps({"error": "Invalid since format. Use YYYY-MM-DD."})
+
+    candidate_limit = max(limit * 4, limit)
+    candidate_matches = db.search_chunks(
+        con,
+        embedding,
+        limit=candidate_limit,
+        platform=platforms,
+        cutoff_iso=cutoff_iso,
+        sort_by_time=sort_by_time,
+        group_thread_ids=group_thread_ids,
+    )
+
+    query_projection = None
+    predicate_candidates = []
+    try:
+        query_itir = enrich_text_with_itir(query)
+        if isinstance(query_itir, dict):
+            query_projection = query_itir.get("predicate_projection")
+    except Exception:
+        query_projection = None
+
+    if query_projection:
+        projection_terms = extract_projection_terms(query_projection)
+        predicate_candidates = db.search_predicate_candidates(
+            con,
+            projection_terms["signatures"],
+            projection_terms["role_arguments"],
+            limit=candidate_limit,
+            platform=platforms,
+            cutoff_iso=cutoff_iso,
+            group_thread_ids=group_thread_ids,
+        )
+
+    if not candidate_matches and not predicate_candidates:
+        out = {"query": query, "count": 0, "results": [], **_current_datetime_json()}
+        return json.dumps(out, indent=2)
+
+    results = build_provenance_ranked_chunk_results(
+        con,
+        candidate_matches,
+        limit=limit,
+        governance_weight=governance_weight,
+        rerank_by_governance=rerank_by_governance,
+        query_projection=query_projection,
+        predicate_candidates=predicate_candidates,
+    )
+
+    out = {
+        "query": query,
+        "count": len(results),
+        "scoring": {
+            "rerank_by_governance": rerank_by_governance,
+            "governance_weight": max(0.0, min(1.0, governance_weight)),
+            "semantic_weight": 1.0 - max(0.0, min(1.0, governance_weight)),
+            "predicate_candidates": len(predicate_candidates),
+        },
+        "results": results,
+        **_current_datetime_json(),
+    }
     return json.dumps(out, indent=2)
 
 

--- a/src/mychatarchive/parsers/__init__.py
+++ b/src/mychatarchive/parsers/__init__.py
@@ -15,6 +15,13 @@ PARSERS = {
 }
 
 DIRECTORY_PARSERS = {"claude_code", "cursor"}
+OPTIONAL_ARCHIVE_FIELDS = (
+    "source_path",
+    "source_bucket",
+    "provenance_json",
+    "content_blocks",
+    "provenance_refs",
+)
 
 
 def detect_format(file_path: Path) -> str | None:
@@ -104,4 +111,13 @@ def parse(file_path: Path, format_name: str | None = None) -> Iterator[dict]:
     if format_name not in PARSERS:
         raise ValueError(f"Unknown format '{format_name}'. Options: {', '.join(PARSERS.keys())}")
 
-    yield from PARSERS[format_name].parse(str(file_path))
+    for message in PARSERS[format_name].parse(str(file_path)):
+        if not isinstance(message, dict):
+            continue
+        normalized = dict(message)
+        normalized.setdefault("thread_title", "")
+        normalized.setdefault("source_message_id", "")
+        for key in OPTIONAL_ARCHIVE_FIELDS:
+            if key in message:
+                normalized[key] = message[key]
+        yield normalized

--- a/src/mychatarchive/parsers/chatgpt.py
+++ b/src/mychatarchive/parsers/chatgpt.py
@@ -57,6 +57,7 @@ def _parse_conversation(convo: dict) -> Iterator[dict]:
             "role": role,
             "content": content,
             "created_at": float(ts),
+            "source_message_id": m.get("id") or node_id,
         })
 
     messages.sort(key=lambda x: x["created_at"])

--- a/src/mychatarchive/retrieval_explain.py
+++ b/src/mychatarchive/retrieval_explain.py
@@ -1,0 +1,328 @@
+"""Provenance/governance-aware retrieval explanation helpers."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from mychatarchive.itir_residuals import summarize_projection_residual
+
+
+SEMANTIC_RESULT_SCHEMA = "mychatarchive.semantic_result.v1"
+
+
+def _load_json(raw: str | None) -> dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _extract_itir_signals(message_meta: dict[str, Any], chunk_meta: dict[str, Any]) -> dict[str, Any]:
+    itir_payload = {}
+    message_itir = message_meta.get("itir")
+    chunk_itir = chunk_meta.get("itir")
+    if isinstance(message_itir, dict):
+        itir_payload = message_itir
+    elif isinstance(chunk_itir, dict):
+        itir_payload = chunk_itir
+
+    tokenizer_receipt = itir_payload.get("tokenizer_profile_receipt")
+    relational_bundle = itir_payload.get("relational_bundle")
+
+    profile_id = None
+    if isinstance(tokenizer_receipt, dict):
+        profile_id = tokenizer_receipt.get("profile_id")
+
+    return {
+        "has_itir_payload": bool(itir_payload),
+        "tokenizer_profile_id": profile_id,
+        "has_relational_bundle": bool(relational_bundle),
+    }
+
+
+def _compute_governance_score(*, source_path: str | None, source_bucket: str | None,
+                              source_thread_id: str | None, source_message_id: str | None,
+                              has_provenance_json: bool, block_count: int, ref_count: int,
+                              has_itir_payload: bool) -> tuple[float, list[str]]:
+    score = 0.0
+    reasons: list[str] = []
+
+    if source_path:
+        score += 0.14
+        reasons.append("source_path_present")
+    if source_bucket:
+        score += 0.08
+        reasons.append("source_bucket_present")
+    if source_thread_id:
+        score += 0.08
+        reasons.append("source_thread_id_present")
+    if source_message_id:
+        score += 0.08
+        reasons.append("source_message_id_present")
+    if has_provenance_json:
+        score += 0.16
+        reasons.append("message_provenance_json_present")
+    if block_count > 0:
+        score += min(block_count, 3) / 3 * 0.16
+        reasons.append(f"message_blocks={block_count}")
+    if ref_count > 0:
+        score += min(ref_count, 3) / 3 * 0.20
+        reasons.append(f"provenance_refs={ref_count}")
+    if has_itir_payload:
+        score += 0.10
+        reasons.append("itir_payload_present")
+
+    return min(score, 1.0), reasons
+
+
+def _tier_for_score(score: float) -> str:
+    if score >= 0.75:
+        return "high"
+    if score >= 0.40:
+        return "medium"
+    return "low"
+
+
+def _source_db_for_connection(con) -> str | None:
+    try:
+        rows = con.execute("PRAGMA database_list").fetchall()
+    except Exception:
+        return None
+    for row in rows:
+        if row[1] == "main":
+            return row[2] or None
+    return None
+
+
+def _missing_contract_fields(result: dict[str, Any]) -> list[str]:
+    required_paths = {
+        "chunk_id": result.get("chunk_id"),
+        "message_id": result.get("message_id"),
+        "canonical_thread_id": result.get("canonical_thread_id"),
+        "provenance.canonical_thread_id": result.get("provenance", {}).get("canonical_thread_id"),
+        "source_db": result.get("source_db"),
+    }
+    return [field for field, value in required_paths.items() if value in (None, "")]
+
+
+def build_provenance_ranked_chunk_results(
+    con,
+    semantic_matches: list[tuple[str, float]],
+    *,
+    limit: int,
+    governance_weight: float = 0.30,
+    rerank_by_governance: bool = True,
+    query_projection: dict[str, Any] | None = None,
+    predicate_candidates: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Build provenance-aware retrieval results from semantic chunk matches."""
+    if not semantic_matches and not predicate_candidates:
+        return []
+
+    weight = max(0.0, min(1.0, governance_weight))
+    rows: list[dict[str, Any]] = []
+    source_db = _source_db_for_connection(con)
+    semantic_by_chunk = {chunk_id: float(distance) for chunk_id, distance in semantic_matches}
+    predicate_by_chunk = {
+        candidate["chunk_id"]: candidate
+        for candidate in (predicate_candidates or [])
+        if candidate.get("chunk_id")
+    }
+    all_chunk_ids = list(dict.fromkeys([*semantic_by_chunk.keys(), *predicate_by_chunk.keys()]))
+
+    for chunk_id in all_chunk_ids:
+        fetched = con.execute(
+            """
+            SELECT c.text, c.canonical_thread_id, c.ts_start, c.ts_end, c.meta, c.message_id,
+                   m.role, m.title, m.source_thread_id, m.source_message_id,
+                   m.source_path, m.source_bucket, m.provenance_json, m.meta,
+                   m.platform, m.account_id, m.source_id, m.ts
+            FROM chunks c
+            LEFT JOIN messages m ON c.message_id = m.message_id
+            WHERE c.chunk_id = ?
+            """,
+            (chunk_id,),
+        ).fetchone()
+        if not fetched:
+            continue
+        columns = [
+            "text",
+            "canonical_thread_id",
+            "ts_start",
+            "ts_end",
+            "chunk_meta",
+            "message_id",
+            "role",
+            "title",
+            "source_thread_id",
+            "source_message_id",
+            "source_path",
+            "source_bucket",
+            "provenance_json",
+            "message_meta",
+            "platform",
+            "account_id",
+            "source_id",
+            "message_ts",
+        ]
+        row = dict(zip(columns, fetched))
+
+        semantic_distance = semantic_by_chunk.get(chunk_id)
+        chunk_meta = _load_json(row["chunk_meta"])
+        message_meta = _load_json(row["message_meta"])
+        message_provenance_json = _load_json(row["provenance_json"])
+        has_provenance_json = bool(message_provenance_json)
+
+        message_id = row["message_id"]
+        block_count = 0
+        ref_count = 0
+        predicate_count = 0
+        if message_id:
+            block_count = con.execute(
+                "SELECT COUNT(*) FROM message_blocks WHERE message_id = ?",
+                (message_id,),
+            ).fetchone()[0]
+            ref_count = con.execute(
+                "SELECT COUNT(*) FROM provenance_refs WHERE message_id = ?",
+                (message_id,),
+            ).fetchone()[0]
+            predicate_count = con.execute(
+                "SELECT COUNT(*) FROM predicate_refs WHERE message_id = ?",
+                (message_id,),
+            ).fetchone()[0]
+
+        itir_signals = _extract_itir_signals(message_meta, chunk_meta)
+        candidate_projection = {}
+        if isinstance(message_meta.get("itir"), dict):
+            candidate_projection = message_meta["itir"].get("predicate_projection") or {}
+        residual_summary = summarize_projection_residual(query_projection, candidate_projection)
+        predicate_candidate = predicate_by_chunk.get(chunk_id) or {}
+        predicate_similarity = float(predicate_candidate.get("predicate_score") or 0.0)
+        governance_score, reasons = _compute_governance_score(
+            source_path=row["source_path"],
+            source_bucket=row["source_bucket"],
+            source_thread_id=row["source_thread_id"],
+            source_message_id=row["source_message_id"],
+            has_provenance_json=has_provenance_json,
+            block_count=block_count,
+            ref_count=ref_count,
+            has_itir_payload=bool(itir_signals["has_itir_payload"]),
+        )
+        governance_score = min(
+            1.0,
+            governance_score
+            + min(predicate_count, 4) * 0.03
+            + (residual_summary["score"] * 0.20 if residual_summary["available"] else 0.0),
+        )
+        if predicate_count > 0:
+            reasons.append(f"predicate_refs={predicate_count}")
+        if residual_summary["available"]:
+            if residual_summary["shared_predicates"]:
+                reasons.append(
+                    "shared_predicates=" + ",".join(residual_summary["shared_predicates"][:4])
+                )
+            if residual_summary["contradictions"]:
+                reasons.append(
+                    "predicate_contradictions=" + ",".join(residual_summary["contradictions"][:4])
+                )
+        if predicate_candidate.get("matched_signatures"):
+            reasons.append(
+                "predicate_candidate_matches="
+                + ",".join(predicate_candidate["matched_signatures"][:4])
+        )
+        semantic_similarity = (
+            max(0.0, 1.0 - float(semantic_distance))
+            if semantic_distance is not None
+            else 0.0
+        )
+        retrieval_similarity = max(semantic_similarity, predicate_similarity)
+        rank_score = (retrieval_similarity * (1.0 - weight)) + (governance_score * weight)
+        excerpt = (row["text"] or "")[:1000]
+
+        result = {
+            "schema": SEMANTIC_RESULT_SCHEMA,
+            "result_type": "message_chunk",
+            "source_db": source_db,
+            "chunk_id": chunk_id,
+            "message_id": message_id,
+            "canonical_thread_id": row["canonical_thread_id"],
+            "thread_id": row["canonical_thread_id"],
+            "source_thread_id": row["source_thread_id"],
+            "source_message_id": row["source_message_id"],
+            "platform": row["platform"],
+            "account_id": row["account_id"],
+            "source_id": row["source_id"],
+            "title": row["title"] or "",
+            "role": row["role"] or "",
+            "timestamp": row["ts_start"],
+            "timestamp_start": row["ts_start"],
+            "timestamp_end": row["ts_end"],
+            "message_timestamp": row["message_ts"],
+            "excerpt": excerpt,
+            "text": excerpt,
+            "scores": {
+                "distance": round(float(semantic_distance), 6) if semantic_distance is not None else None,
+                "semantic_distance": (
+                    round(float(semantic_distance), 6) if semantic_distance is not None else None
+                ),
+                "similarity": round(retrieval_similarity, 4),
+                "semantic_similarity": round(semantic_similarity, 4),
+                "predicate_similarity": round(predicate_similarity, 4),
+                "rank_score": round(rank_score, 4),
+                "governance_score": round(governance_score, 4),
+            },
+            "similarity": round(retrieval_similarity, 4),
+            "semantic_similarity": round(semantic_similarity, 4),
+            "predicate_similarity": round(predicate_similarity, 4),
+            "rank_score": round(rank_score, 4),
+            "provenance": {
+                "canonical_thread_id": row["canonical_thread_id"],
+                "message_id": message_id,
+                "chunk_id": chunk_id,
+                "source_thread_id": row["source_thread_id"],
+                "source_message_id": row["source_message_id"],
+                "source_path": row["source_path"],
+                "source_bucket": row["source_bucket"],
+                "source_id": row["source_id"],
+                "provenance_json": message_provenance_json or None,
+            },
+            "governance": {
+                "score": round(governance_score, 4),
+                "tier": _tier_for_score(governance_score),
+                "signals": reasons,
+                "source": {
+                    "source_thread_id": row["source_thread_id"],
+                    "source_message_id": row["source_message_id"],
+                    "source_path": row["source_path"],
+                    "source_bucket": row["source_bucket"],
+                    "source_id": row["source_id"],
+                },
+                "evidence_counts": {
+                    "message_blocks": block_count,
+                    "provenance_refs": ref_count,
+                    "predicate_refs": predicate_count,
+                },
+                "itir": itir_signals,
+                "predicate_residual": residual_summary,
+            },
+        }
+        missing_fields = _missing_contract_fields(result)
+        if missing_fields:
+            result["warnings"] = [
+                {
+                    "code": "semantic_result_missing_provenance",
+                    "missing_fields": missing_fields,
+                    "message": "Semantic result has incomplete canonical provenance.",
+                }
+            ]
+
+        rows.append(result)
+
+    if rerank_by_governance:
+        rows.sort(key=lambda item: (item["rank_score"], item["similarity"]), reverse=True)
+
+    return rows[:limit]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -30,6 +30,13 @@ def test_schema_creation(test_db):
     assert "messages" in tables
     assert "chunks" in tables
     assert "thoughts" in tables
+    cols = {
+        row[1]
+        for row in con.execute("PRAGMA table_info(messages)").fetchall()
+    }
+    assert "meta" in cols
+    assert "source_thread_id" in cols
+    assert "source_message_id" in cols
 
 
 def test_insert_message(test_db):
@@ -37,9 +44,19 @@ def test_insert_message(test_db):
     result = db.insert_message(
         con, "msg1", "thread1", "chatgpt", "main",
         "2026-01-01T00:00:00Z", "user", "Hello world", "Test", "src1",
+        "conv-123", "msg-upstream-1",
+        {"itir": {"tokenizer_profile_receipt": {"profile_id": "abc"}}},
     )
     assert result is True
     assert db.message_count(con) == 1
+    stored = con.execute(
+        "SELECT source_thread_id, source_message_id, meta FROM messages WHERE message_id = ?",
+        ("msg1",),
+    ).fetchone()
+    assert stored[0] == "conv-123"
+    assert stored[1] == "msg-upstream-1"
+    assert stored[2] is not None
+    assert "profile_id" in stored[2]
 
     dupe = db.insert_message(
         con, "msg1", "thread1", "chatgpt", "main",

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -37,6 +37,13 @@ def test_schema_creation(test_db):
     assert "meta" in cols
     assert "source_thread_id" in cols
     assert "source_message_id" in cols
+    assert "source_path" in cols
+    assert "source_bucket" in cols
+    assert "provenance_json" in cols
+    assert "message_blocks" in tables
+    assert "provenance_refs" in tables
+    assert "predicate_refs" in tables
+    assert "predicate_roles" in tables
 
 
 def test_insert_message(test_db):
@@ -64,6 +71,47 @@ def test_insert_message(test_db):
     )
     assert dupe is False
     assert db.message_count(con) == 1
+
+
+def test_insert_message_with_extended_provenance(test_db):
+    con, _ = test_db
+    result = db.insert_message(
+        con, "msg-provenance-1", "thread-provenance", "chatgpt", "main",
+        "2026-01-02T00:00:00Z", "assistant", "Answer", "Test", "src-provenance",
+        source_thread_id="conv-456",
+        source_message_id="msg-upstream-2",
+        source_path="/exports/chatgpt/account-a/export.json",
+        source_bucket="chatgpt_export",
+        provenance_json={
+            "root_import_id": "imp-1",
+            "trace": [{"step": "parse", "parser": "chatgpt"}],
+        },
+        meta={"ingest": {"stage": "1"}},
+    )
+    assert result is True
+
+    stored = con.execute(
+        """
+        SELECT source_path, source_bucket, provenance_json, meta
+        FROM messages WHERE message_id = ?
+        """,
+        ("msg-provenance-1",),
+    ).fetchone()
+    assert stored is not None
+    assert stored[0] == "/exports/chatgpt/account-a/export.json"
+    assert stored[1] == "chatgpt_export"
+    assert '"root_import_id": "imp-1"' in stored[2]
+    assert '"stage": "1"' in stored[3]
+
+    row = next(iter(db.iter_messages(con, batch_size=1)))
+    assert row["source_path"] == "/exports/chatgpt/account-a/export.json"
+    assert row["source_bucket"] == "chatgpt_export"
+    assert row["provenance_json"]["root_import_id"] == "imp-1"
+
+    exported = db.export_messages(con)
+    assert exported[0]["source_path"] == "/exports/chatgpt/account-a/export.json"
+    assert exported[0]["source_bucket"] == "chatgpt_export"
+    assert exported[0]["provenance_json"]["root_import_id"] == "imp-1"
 
 
 def test_insert_chunk_and_search(test_db):
@@ -94,3 +142,252 @@ def test_insert_thought_and_search(test_db):
 
     results = db.search_thoughts(con, fake_embedding, limit=5)
     assert len(results) > 0
+    assert results[0][0] == "thought1"
+
+
+def test_message_schema_migration_preserves_existing_rows():
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        db_path = Path(f.name)
+
+    con = db.get_connection(db_path)
+    try:
+        con.executescript("""
+            CREATE TABLE messages (
+                message_id TEXT PRIMARY KEY,
+                canonical_thread_id TEXT NOT NULL,
+                platform TEXT NOT NULL,
+                account_id TEXT NOT NULL,
+                ts TEXT NOT NULL,
+                role TEXT NOT NULL,
+                text TEXT NOT NULL,
+                title TEXT,
+                source_id TEXT NOT NULL,
+                source_thread_id TEXT,
+                source_message_id TEXT,
+                meta TEXT
+            );
+            INSERT INTO messages (
+                message_id, canonical_thread_id, platform, account_id, ts, role,
+                text, title, source_id, source_thread_id, source_message_id, meta
+            )
+            VALUES (
+                'legacy-msg-1', 'legacy-thread', 'chatgpt', 'main',
+                '2025-01-01T00:00:00Z', 'user', 'Legacy body', 'Legacy title',
+                'legacy-src', 'legacy-upstream-thread', 'legacy-upstream-message',
+                '{"legacy": true}'
+            );
+        """)
+        con.commit()
+
+        db.ensure_schema(con)
+
+        cols = {
+            row[1]
+            for row in con.execute("PRAGMA table_info(messages)").fetchall()
+        }
+        assert "source_path" in cols
+        assert "source_bucket" in cols
+        assert "provenance_json" in cols
+
+        row = con.execute(
+            """
+            SELECT text, source_thread_id, source_message_id, source_path, source_bucket,
+                   provenance_json, meta
+            FROM messages WHERE message_id = 'legacy-msg-1'
+            """
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "Legacy body"
+        assert row[1] == "legacy-upstream-thread"
+        assert row[2] == "legacy-upstream-message"
+        assert row[3] is None
+        assert row[4] is None
+        assert row[5] is None
+        assert row[6] == '{"legacy": true}'
+
+        tables = {
+            r[0]
+            for r in con.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert "message_blocks" in tables
+        assert "provenance_refs" in tables
+    finally:
+        con.close()
+        db_path.unlink(missing_ok=True)
+
+
+def test_message_blocks_and_provenance_refs_helpers(test_db):
+    con, _ = test_db
+    inserted = db.insert_message(
+        con, "msg-block-1", "thread-block", "chatgpt", "main",
+        "2026-01-03T00:00:00Z", "user", "source text", "Title", "src-block",
+    )
+    assert inserted is True
+
+    block_inserted = db.insert_message_block(
+        con,
+        block_id="blk-1",
+        message_id="msg-block-1",
+        canonical_thread_id="thread-block",
+        block_index=0,
+        block_type="text",
+        text="source text",
+        source_path="/exports/a.json",
+        source_bucket="chatgpt_export",
+        provenance_json={"span": [0, 11]},
+        meta={"normalized": True},
+    )
+    assert block_inserted is True
+    assert db.insert_message_block(
+        con,
+        block_id="blk-1",
+        message_id="msg-block-1",
+        canonical_thread_id="thread-block",
+        block_index=0,
+        block_type="text",
+        text="source text",
+    ) is False
+
+    ref_inserted = db.insert_provenance_ref(
+        con,
+        provenance_ref_id="pref-1",
+        message_id="msg-block-1",
+        block_id="blk-1",
+        ref_index=0,
+        source_id="src-block",
+        source_thread_id="upstream-thread",
+        source_message_id="upstream-message",
+        source_path="/exports/a.json",
+        source_bucket="chatgpt_export",
+        locator_json={"offset": 0},
+        meta={"score": 1.0},
+    )
+    assert ref_inserted is True
+    assert db.insert_provenance_ref(
+        con,
+        provenance_ref_id="pref-1",
+        message_id="msg-block-1",
+        block_id="blk-1",
+        ref_index=0,
+    ) is False
+
+    blocks = db.list_message_blocks(con, message_id="msg-block-1")
+    assert len(blocks) == 1
+    assert blocks[0]["block_id"] == "blk-1"
+    assert blocks[0]["source_bucket"] == "chatgpt_export"
+    assert blocks[0]["provenance_json"]["span"] == [0, 11]
+
+    refs = db.list_provenance_refs(con, message_id="msg-block-1")
+    assert len(refs) == 1
+    assert refs[0]["provenance_ref_id"] == "pref-1"
+    assert refs[0]["source_thread_id"] == "upstream-thread"
+    assert refs[0]["locator_json"]["offset"] == 0
+
+
+def test_predicate_projection_helpers(test_db):
+    con, _ = test_db
+    inserted = db.insert_message(
+        con, "msg-pred-1", "thread-pred", "chatgpt", "main",
+        "2026-01-04T00:00:00Z", "assistant", "Predicate text", "Pred", "src-pred",
+    )
+    assert inserted is True
+
+    projection = {
+        "version": "itir_predicate_projection_v1",
+        "limits": {"max_predicates": 64},
+        "counts": {"predicates_total": 1, "predicates_projected": 1, "predicates_truncated": False},
+        "predicates": [
+            {
+                "ref": "pred:1",
+                "atom_id": "pred:1",
+                "predicate": "pay",
+                "structural_signature": "pay",
+                "roles": [
+                    {"name": "subject", "value": "tenant", "status": "bound", "provenance_refs": ["head:0-5"]},
+                    {"name": "object", "value": "rent", "status": "bound", "provenance_refs": ["arg:6-10"]},
+                ],
+                "polarity": "positive",
+                "modality": "must",
+                "provenance_refs": ["pred:1"],
+                "source_spans": [{"start": 0, "end": 5, "ref": "head:0-5"}],
+                "wrapper": {"status": "structural_projection", "evidence_only": True},
+            }
+        ],
+        "index": {"by_structural_signature": {"pay": ["pred:1"]}},
+    }
+    count = db.insert_predicate_projection(con, "msg-pred-1", "thread-pred", projection)
+    assert count == 1
+
+    predicate_refs = db.list_predicate_refs(con, message_id="msg-pred-1")
+    assert len(predicate_refs) == 1
+    assert predicate_refs[0]["predicate"] == "pay"
+    assert predicate_refs[0]["modality"] == "must"
+
+    predicate_roles = db.list_predicate_roles(con, message_id="msg-pred-1")
+    assert len(predicate_roles) == 2
+    assert {role["role_name"] for role in predicate_roles} == {"subject", "object"}
+
+
+def test_search_predicate_candidates_returns_scored_shortlist(test_db):
+    con, _ = test_db
+    db.insert_message(
+        con,
+        "msg-pred-search-1",
+        "thread-pred-search",
+        "chatgpt",
+        "main",
+        "2026-02-01T00:00:00Z",
+        "assistant",
+        "Tenant must pay rent immediately.",
+        "Predicate search",
+        "src-pred-search",
+    )
+    db.insert_chunk(
+        con,
+        "chunk-pred-search-1",
+        "msg-pred-search-1",
+        "thread-pred-search",
+        0,
+        "Tenant must pay rent immediately.",
+        "2026-02-01T00:00:00Z",
+        "2026-02-01T00:00:00Z",
+        [0.3] * 384,
+        {"role": "assistant"},
+    )
+    db.insert_predicate_projection(
+        con,
+        "msg-pred-search-1",
+        "thread-pred-search",
+        {
+            "version": "itir_predicate_projection_v1",
+            "predicates": [
+                {
+                    "ref": "pred:pay",
+                    "predicate": "pay",
+                    "structural_signature": "pay",
+                    "roles": [
+                        {"name": "subject", "value": "tenant"},
+                        {"name": "object", "value": "rent"},
+                    ],
+                    "polarity": "positive",
+                }
+            ],
+        },
+    )
+    con.commit()
+
+    matches = db.search_predicate_candidates(
+        con,
+        ["pay"],
+        ["subject|tenant", "object|rent"],
+        limit=5,
+    )
+
+    assert len(matches) == 1
+    assert matches[0]["message_id"] == "msg-pred-search-1"
+    assert matches[0]["chunk_id"] == "chunk-pred-search-1"
+    assert matches[0]["matched_signatures"] == ["pay"]
+    assert set(matches[0]["matched_role_arguments"]) == {"subject|tenant", "object|rent"}
+    assert matches[0]["predicate_score"] == pytest.approx(1.0)

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -1,0 +1,152 @@
+from mychatarchive.hybrid_search import (
+    HybridSearchResult,
+    keyword_candidates,
+    merge_candidates,
+    search_hybrid,
+)
+
+
+class FakeConnection:
+    def __init__(self, chunk_rows):
+        self.chunk_rows = chunk_rows
+
+    def execute(self, _sql, params):
+        wanted = set(params)
+        return FakeCursor([row for row in self.chunk_rows if row[0] in wanted])
+
+
+class FakeCursor:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def fetchall(self):
+        return self.rows
+
+
+def test_keyword_exact_identifier_beats_high_semantic_similarity():
+    keyword = keyword_candidates(
+        [
+            (
+                "msg-exact-42",
+                "Short exact identifier hit",
+                "thread-alpha",
+                "2026-01-01T00:00:00Z",
+                "assistant",
+                "Exact Thread",
+            )
+        ],
+        "msg-exact-42",
+    )
+    semantic = [
+        HybridSearchResult(
+            result_id="msg-semantic",
+            match_key="message:msg-semantic",
+            thread_id="thread-beta",
+            message_id="msg-semantic",
+            chunk_id="chunk-semantic",
+            text="A vague but semantically close discussion",
+            title="Semantic Thread",
+            role="assistant",
+            timestamp="2026-01-02T00:00:00Z",
+            source=["semantic"],
+            semantic_rank=1,
+            semantic_score=0.98,
+            distance=0.02,
+        )
+    ]
+
+    results = merge_candidates(keyword, semantic, query="msg-exact-42", limit=2)
+
+    assert results[0].message_id == "msg-exact-42"
+    assert results[0].exact_score == 1.0
+    assert results[1].message_id == "msg-semantic"
+
+
+def test_merge_combines_keyword_and_semantic_for_same_message():
+    keyword = keyword_candidates(
+        [
+            (
+                "msg-shared",
+                "The canonical archive bridge preserves source ids.",
+                "thread-shared",
+                "2026-01-01T00:00:00Z",
+                "user",
+                "Bridge",
+            )
+        ],
+        "canonical archive bridge",
+    )
+    semantic = [
+        HybridSearchResult(
+            result_id="msg-shared",
+            match_key="message:msg-shared",
+            thread_id="thread-shared",
+            message_id="msg-shared",
+            chunk_id="chunk-shared",
+            text="The canonical archive bridge preserves source ids.",
+            title="Bridge",
+            role="user",
+            timestamp="2026-01-01T00:00:00Z",
+            source=["semantic"],
+            semantic_rank=1,
+            semantic_score=0.9,
+            distance=0.1,
+        )
+    ]
+
+    results = merge_candidates(keyword, semantic, query="canonical archive bridge", limit=1)
+
+    assert len(results) == 1
+    assert set(results[0].source) == {"keyword", "semantic"}
+    assert results[0].keyword_score > 0
+    assert results[0].semantic_score == 0.9
+    assert results[0].distance == 0.1
+
+
+def test_search_hybrid_uses_injected_searchers_and_returns_json_ready_results():
+    con = FakeConnection(
+        [
+            (
+                "chunk-shared",
+                "msg-shared",
+                "thread-shared",
+                "Hybrid retrieval should preserve canonical ids.",
+                "2026-01-01T00:00:00Z",
+                None,
+                "assistant",
+                "Hybrid",
+            )
+        ]
+    )
+
+    def keyword_search(*_args, **_kwargs):
+        return [
+            (
+                "msg-shared",
+                "Hybrid retrieval should preserve canonical ids.",
+                "thread-shared",
+                "2026-01-01T00:00:00Z",
+                "assistant",
+                "Hybrid",
+            )
+        ]
+
+    def semantic_search(*_args, **_kwargs):
+        return [("chunk-shared", 0.2)]
+
+    results = search_hybrid(
+        con,
+        "canonical ids",
+        [0.0, 1.0],
+        limit=5,
+        keyword_search=keyword_search,
+        semantic_search=semantic_search,
+    )
+
+    assert len(results) == 1
+    assert results[0]["message_id"] == "msg-shared"
+    assert results[0]["thread_id"] == "thread-shared"
+    assert results[0]["chunk_id"] == "chunk-shared"
+    assert set(results[0]["source"]) == {"keyword", "semantic"}
+    assert results[0]["scores"]["keyword"] > 0
+    assert results[0]["scores"]["semantic"] == 0.8

--- a/tests/test_ingest_bridge.py
+++ b/tests/test_ingest_bridge.py
@@ -1,0 +1,398 @@
+"""Tests for ingest bridge compatibility and optional archive-truth propagation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import json
+import sqlite3
+
+import pytest
+
+from mychatarchive import db, ingest, ingest_bridge
+
+
+def _mock_connection():
+    return SimpleNamespace(commit=lambda: None, close=lambda: None)
+
+
+def test_ingest_parsed_messages_legacy_shape(tmp_path, monkeypatch):
+    db_path = tmp_path / "legacy.sqlite"
+    monkeypatch.setattr(
+        ingest,
+        "enrich_text_with_itir",
+        lambda text: {"tokenizer_profile_receipt": {"profile_id": "stub"}, "text": text},
+    )
+    monkeypatch.setattr(db, "get_connection", lambda _path: _mock_connection())
+    monkeypatch.setattr(db, "ensure_schema", lambda _con: None)
+
+    captured: dict[str, object] = {}
+
+    def fake_insert_message(
+        con,
+        message_id,
+        canonical_thread_id,
+        platform,
+        account_id,
+        ts,
+        role,
+        text,
+        title,
+        source_id,
+        source_thread_id=None,
+        source_message_id=None,
+        meta=None,
+    ):
+        captured["source_thread_id"] = source_thread_id
+        captured["source_message_id"] = source_message_id
+        captured["meta"] = meta
+        return True
+
+    monkeypatch.setattr(db, "insert_message", fake_insert_message)
+
+    messages = [
+        {
+            "thread_id": "thread-legacy",
+            "thread_title": "Legacy",
+            "role": "user",
+            "content": "hello legacy",
+            "created_at": 1700000000.0,
+        }
+    ]
+
+    inserted, duplicates = ingest.ingest_parsed_messages(
+        messages,
+        db_path=db_path,
+        platform="chatgpt",
+        account_id="main",
+        source_id="source_legacy",
+    )
+
+    assert inserted == 1
+    assert duplicates == 0
+    assert captured["source_thread_id"] == "thread-legacy"
+    assert captured["source_message_id"] is None
+    meta = captured["meta"]
+    assert isinstance(meta, dict)
+    assert meta["itir"]["tokenizer_profile_receipt"]["profile_id"] == "stub"
+    assert "archive_truth" not in meta
+
+
+def test_ingest_optional_fields_bridge_to_insert_and_side_writers(tmp_path, monkeypatch):
+    db_path = tmp_path / "bridge.sqlite"
+    monkeypatch.setattr(
+        ingest,
+        "enrich_text_with_itir",
+        lambda text: {"tokenizer_profile_receipt": {"profile_id": "stub"}, "text": text},
+    )
+    monkeypatch.setattr(db, "get_connection", lambda _path: _mock_connection())
+    monkeypatch.setattr(db, "ensure_schema", lambda _con: None)
+
+    captured: dict[str, object] = {}
+    blocks_calls: list[tuple[str, object]] = []
+    refs_calls: list[tuple[str, object]] = []
+
+    def fake_insert_message(
+        con,
+        message_id,
+        canonical_thread_id,
+        platform,
+        account_id,
+        ts,
+        role,
+        text,
+        title,
+        source_id,
+        source_thread_id=None,
+        source_message_id=None,
+        meta=None,
+        source_path=None,
+        source_bucket=None,
+        provenance_json=None,
+    ):
+        captured["message_id"] = message_id
+        captured["source_path"] = source_path
+        captured["source_bucket"] = source_bucket
+        captured["provenance_json"] = provenance_json
+        captured["meta"] = meta
+        return True
+
+    def fake_insert_message_blocks(con, message_id, blocks):
+        blocks_calls.append((message_id, blocks))
+
+    def fake_insert_provenance_refs(con, message_id, refs):
+        refs_calls.append((message_id, refs))
+
+    monkeypatch.setattr(db, "insert_message", fake_insert_message)
+    monkeypatch.setattr(db, "insert_message_blocks", fake_insert_message_blocks, raising=False)
+    monkeypatch.setattr(db, "insert_provenance_refs", fake_insert_provenance_refs, raising=False)
+
+    messages = [
+        {
+            "thread_id": "thread-bridge",
+            "thread_title": "Bridge",
+            "role": "assistant",
+            "content": "hello bridge",
+            "created_at": 1700000001.0,
+            "source_message_id": "src-msg-1",
+            "source_path": "/exports/bridge.json",
+            "source_bucket": "drop_folder",
+            "provenance_json": {"origin": "chat-export-structurer"},
+            "content_blocks": [{"kind": "text", "text": "hello bridge"}],
+            "provenance_refs": [{"type": "file", "id": "ref-1"}],
+        }
+    ]
+
+    inserted, duplicates = ingest.ingest_parsed_messages(
+        messages,
+        db_path=db_path,
+        platform="chatgpt",
+        account_id="main",
+        source_id="source_bridge",
+    )
+
+    assert inserted == 1
+    assert duplicates == 0
+    assert captured["source_path"] == "/exports/bridge.json"
+    assert captured["source_bucket"] == "drop_folder"
+    assert captured["provenance_json"] == {"origin": "chat-export-structurer"}
+    assert isinstance(captured["meta"], dict)
+    assert "archive_truth" in captured["meta"]
+    assert captured["meta"]["archive_truth"]["content_blocks"] == [
+        {"kind": "text", "text": "hello bridge"}
+    ]
+    assert captured["meta"]["archive_truth"]["provenance_refs"] == [
+        {"type": "file", "id": "ref-1"}
+    ]
+
+    assert len(blocks_calls) == 1
+    assert blocks_calls[0][0] == captured["message_id"]
+    assert blocks_calls[0][1] == [{"kind": "text", "text": "hello bridge"}]
+
+    assert len(refs_calls) == 1
+    assert refs_calls[0][0] == captured["message_id"]
+    assert refs_calls[0][1] == [{"type": "file", "id": "ref-1"}]
+
+
+def test_ingest_persists_predicate_projection_when_available(tmp_path, monkeypatch):
+    db_path = tmp_path / "predicate.sqlite"
+    monkeypatch.setattr(
+        ingest,
+        "enrich_text_with_itir",
+        lambda text: {
+            "tokenizer_profile_receipt": {"profile_id": "stub"},
+            "predicate_projection": {
+                "version": "itir_predicate_projection_v1",
+                "predicates": [{"ref": "pred:1", "predicate": "pay", "roles": []}],
+            },
+        },
+    )
+    monkeypatch.setattr(db, "get_connection", lambda _path: _mock_connection())
+    monkeypatch.setattr(db, "ensure_schema", lambda _con: None)
+    monkeypatch.setattr(db, "insert_message", lambda *args, **kwargs: True)
+
+    projection_calls: list[tuple[str, str, object]] = []
+
+    def fake_insert_predicate_projection(con, message_id, canonical_thread_id, projection):
+        projection_calls.append((message_id, canonical_thread_id, projection))
+        return 1
+
+    monkeypatch.setattr(db, "insert_predicate_projection", fake_insert_predicate_projection, raising=False)
+
+    messages = [
+        {
+            "thread_id": "thread-predicate",
+            "thread_title": "Predicate",
+            "role": "assistant",
+            "content": "tenant must pay rent",
+            "created_at": 1700000002.0,
+        }
+    ]
+
+    inserted, duplicates = ingest.ingest_parsed_messages(
+        messages,
+        db_path=db_path,
+        platform="chatgpt",
+        account_id="main",
+        source_id="source_predicate",
+    )
+
+    assert inserted == 1
+    assert duplicates == 0
+    assert len(projection_calls) == 1
+    assert projection_calls[0][2]["version"] == "itir_predicate_projection_v1"
+
+
+def _create_canonical_archive(path):
+    con = sqlite3.connect(path)
+    con.execute(
+        """
+        CREATE TABLE messages (
+            message_id TEXT PRIMARY KEY,
+            canonical_thread_id TEXT NOT NULL,
+            platform TEXT,
+            account_id TEXT,
+            ts TEXT NOT NULL,
+            role TEXT NOT NULL,
+            text TEXT NOT NULL,
+            title TEXT,
+            source_id TEXT,
+            source_thread_id TEXT,
+            source_message_id TEXT,
+            source_path TEXT,
+            source_bucket TEXT,
+            provenance_json TEXT,
+            meta TEXT
+        )
+        """
+    )
+    con.executemany(
+        """
+        INSERT INTO messages (
+            message_id, canonical_thread_id, platform, account_id, ts, role, text,
+            title, source_id, source_thread_id, source_message_id, source_path,
+            source_bucket, provenance_json, meta
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        """,
+        [
+            (
+                "canon-msg-1",
+                "canon-thread-1",
+                "chatgpt",
+                "acct-a",
+                "2026-01-01T00:00:00+00:00",
+                "user",
+                "Canonical bridge question",
+                "Bridge Thread",
+                "structurer-src",
+                "online-thread-1",
+                "online-msg-1",
+                "/exports/chatgpt.json",
+                "canonical_archive",
+                json.dumps({"origin": "structurer"}),
+                json.dumps({"existing": {"key": "value"}}),
+            ),
+            (
+                "canon-msg-2",
+                "canon-thread-1",
+                "chatgpt",
+                "acct-a",
+                "2026-01-01T00:01:00+00:00",
+                "assistant",
+                "Canonical bridge answer",
+                "Bridge Thread",
+                "structurer-src",
+                "online-thread-1",
+                "online-msg-2",
+                "/exports/chatgpt.json",
+                "canonical_archive",
+                None,
+                None,
+            ),
+        ],
+    )
+    con.commit()
+    con.close()
+
+
+def test_import_canonical_archive_is_idempotent_and_preserves_provenance(tmp_path):
+    canonical_path = tmp_path / "canonical.sqlite"
+    mca_path = tmp_path / "mca.sqlite"
+    _create_canonical_archive(canonical_path)
+
+    first = ingest_bridge.import_canonical_archive(canonical_path, mca_path)
+    second = ingest_bridge.import_canonical_archive(canonical_path, mca_path)
+
+    assert first.as_dict()["inserted"] == 2
+    assert first.duplicates == 0
+    assert first.skipped == 0
+    assert second.inserted == 0
+    assert second.duplicates == 2
+
+    con = db.get_connection(mca_path)
+    try:
+        rows = db.export_messages(con)
+    finally:
+        con.close()
+
+    assert [row["message_id"] for row in rows] == ["canon-msg-1", "canon-msg-2"]
+    first_row = rows[0]
+    assert first_row["thread_id"] == "canon-thread-1"
+    assert first_row["source_thread_id"] == "online-thread-1"
+    assert first_row["source_message_id"] == "online-msg-1"
+    assert first_row["source_path"] == "/exports/chatgpt.json"
+    assert first_row["source_bucket"] == "canonical_archive"
+    assert first_row["provenance_json"]["origin"] == "structurer"
+    assert first_row["provenance_json"]["bridge"]["kind"] == "canonical_archive_to_mychatarchive"
+    assert first_row["meta"]["existing"]["key"] == "value"
+    assert first_row["meta"]["canonical_bridge"]["canonical_message_id"] == "canon-msg-1"
+
+
+def test_import_canonical_archive_accepts_legacy_alias_schema(tmp_path):
+    canonical_path = tmp_path / "legacy_canonical.sqlite"
+    mca_path = tmp_path / "mca.sqlite"
+    con = sqlite3.connect(canonical_path)
+    con.execute(
+        """
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY,
+            thread_hash TEXT NOT NULL,
+            conversation_id TEXT,
+            created_at REAL NOT NULL,
+            speaker TEXT NOT NULL,
+            content TEXT NOT NULL,
+            thread_title TEXT
+        )
+        """
+    )
+    con.execute(
+        """
+        INSERT INTO messages (
+            id, thread_hash, conversation_id, created_at, speaker, content, thread_title
+        ) VALUES (?,?,?,?,?,?,?)
+        """,
+        (
+            "legacy-msg-1",
+            "legacy-thread-1",
+            "online-legacy-thread",
+            1767225600.0,
+            "user",
+            "Legacy canonical content",
+            "Legacy Bridge",
+        ),
+    )
+    con.commit()
+    con.close()
+
+    result = ingest_bridge.import_canonical_archive(
+        canonical_path,
+        mca_path,
+        default_platform="perplexity",
+        source_id="legacy-source",
+    )
+
+    assert result.inserted == 1
+    con = db.get_connection(mca_path)
+    try:
+        row = db.export_messages(con)[0]
+    finally:
+        con.close()
+
+    assert row["message_id"] == "legacy-msg-1"
+    assert row["thread_id"] == "legacy-thread-1"
+    assert row["platform"] == "perplexity"
+    assert row["source_thread_id"] == "online-legacy-thread"
+    assert row["source_message_id"] == "legacy-msg-1"
+    assert row["source_id"] == "legacy-source"
+
+
+def test_import_canonical_archive_requires_messages_table(tmp_path):
+    canonical_path = tmp_path / "not_canonical.sqlite"
+    mca_path = tmp_path / "mca.sqlite"
+    con = sqlite3.connect(canonical_path)
+    con.execute("CREATE TABLE other (id TEXT)")
+    con.commit()
+    con.close()
+
+    with pytest.raises(ValueError, match="messages table"):
+        ingest_bridge.import_canonical_archive(canonical_path, mca_path)

--- a/tests/test_itir.py
+++ b/tests/test_itir.py
@@ -1,0 +1,77 @@
+"""Tests for required ITIR enrichment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mychatarchive import itir
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_enrich_text_uses_local_shared_reducer(monkeypatch, tmp_path):
+    fake_root = tmp_path / "SensibLaw"
+    _write(
+        fake_root / "src" / "sensiblaw" / "__init__.py",
+        "",
+    )
+    _write(
+        fake_root / "src" / "sensiblaw" / "interfaces" / "__init__.py",
+        "",
+    )
+    _write(
+        fake_root / "src" / "sensiblaw" / "interfaces" / "shared_reducer.py",
+        """
+from dataclasses import dataclass
+
+def get_canonical_tokenizer_profile_receipt():
+    return {"profile_id": "fake", "canonical_mode": "deterministic_legal"}
+
+def tokenize_canonical_with_spans(text):
+    return [("hello", 0, 5), ("world", 6, 11)]
+
+def collect_canonical_lexeme_refs(text):
+    return [{"occurrence_id": "abc", "kind": "word", "span_start": 0, "span_end": 5}]
+
+@dataclass(frozen=True)
+class _Structure:
+    text: str
+    norm_text: str
+    kind: str
+    start_char: int
+    end_char: int
+    flags: int = 0
+
+def collect_canonical_structure_occurrences(text):
+    return [_Structure("hello", "hello", "word_ref", 0, 5, 0)]
+
+def collect_canonical_relational_bundle(text):
+    return {"version": "relational_bundle_v1", "canonical_text": text, "atoms": [], "relations": []}
+""",
+    )
+
+    itir._load_enrichment.cache_clear()
+    monkeypatch.setenv("MYCHATARCHIVE_ITIR_PATHS", str(fake_root))
+
+    payload = itir.enrich_text("hello world")
+
+    assert payload is not None
+    assert payload["surface"] == "sensiblaw.interfaces.shared_reducer"
+    assert payload["source_root"] == str(fake_root.resolve())
+    assert payload["token_spans"][0]["text"] == "hello"
+    assert payload["lexeme_refs"][0]["occurrence_id"] == "abc"
+    assert payload["structure_occurrences"][0]["kind"] == "word_ref"
+    assert payload["relational_bundle"]["version"] == "relational_bundle_v1"
+
+
+def test_enrich_text_raises_when_missing(monkeypatch, tmp_path):
+    itir._load_enrichment.cache_clear()
+    monkeypatch.setattr("mychatarchive.itir.get_itir_paths", lambda: [tmp_path / "missing"])
+    monkeypatch.delenv("MYCHATARCHIVE_ITIR_PATHS", raising=False)
+    with pytest.raises(RuntimeError):
+        itir.enrich_text("hello world")

--- a/tests/test_itir.py
+++ b/tests/test_itir.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import sys
 
 import pytest
 
@@ -52,10 +53,54 @@ def collect_canonical_structure_occurrences(text):
 
 def collect_canonical_relational_bundle(text):
     return {"version": "relational_bundle_v1", "canonical_text": text, "atoms": [], "relations": []}
+
+def collect_canonical_predicate_atoms(text):
+    return [
+        {
+            "atom_id": "pred:1",
+            "predicate": "pay",
+            "structural_signature": "pay",
+            "roles": {
+                "subject": {
+                    "value": "tenant",
+                    "status": "bound",
+                    "entity_type": "person",
+                    "provenance": ["head:0-5"],
+                },
+                "object": {
+                    "value": "rent",
+                    "status": "bound",
+                    "provenance": ["arg:6-11"],
+                },
+            },
+            "qualifiers": {"polarity": "negative", "modality": "must"},
+            "wrapper": {"status": "structural_projection", "evidence_only": True},
+            "provenance": ["pred:1", "head:0-5", "arg:6-11"],
+        }
+    ]
+
+def build_predicate_ref_map(atoms):
+    refs = {}
+    for index, atom in enumerate(atoms):
+        ref = atom.get("atom_id") or f"pnf:{index}"
+        refs[ref] = atom
+    return refs
+
+def build_predicate_index(atoms):
+    refs = [atom.get("atom_id", "pnf:0") for atom in atoms]
+    return {
+        "by_structural_sig": {"pay": refs},
+        "by_role_slot": {"subject": refs, "object": refs},
+        "by_argval": {"tenant": refs, "rent": refs},
+        "by_role_arg": {("subject", "tenant"): refs, ("object", "rent"): refs},
+    }
 """,
     )
 
     itir._load_enrichment.cache_clear()
+    for module_name in list(sys.modules):
+        if module_name == "sensiblaw" or module_name.startswith("sensiblaw."):
+            sys.modules.pop(module_name, None)
     monkeypatch.setenv("MYCHATARCHIVE_ITIR_PATHS", str(fake_root))
 
     payload = itir.enrich_text("hello world")
@@ -67,6 +112,53 @@ def collect_canonical_relational_bundle(text):
     assert payload["lexeme_refs"][0]["occurrence_id"] == "abc"
     assert payload["structure_occurrences"][0]["kind"] == "word_ref"
     assert payload["relational_bundle"]["version"] == "relational_bundle_v1"
+    assert payload["predicate_projection"]["version"] == "itir_predicate_projection_v1"
+    assert payload["predicate_projection"]["predicates"][0]["ref"] == "pred:1"
+    assert payload["predicate_projection"]["predicates"][0]["predicate"] == "pay"
+    assert payload["predicate_projection"]["predicates"][0]["structural_signature"] == "pay"
+    assert payload["predicate_projection"]["predicates"][0]["polarity"] == "negative"
+    assert payload["predicate_projection"]["predicates"][0]["modality"] == "must"
+    assert payload["predicate_projection"]["predicates"][0]["roles"][0]["name"] == "object"
+    assert payload["predicate_projection"]["predicates"][0]["source_spans"][0]["start"] == 0
+    assert payload["predicate_projection"]["index"]["by_role_argument"]["subject|tenant"] == ["pred:1"]
+
+
+def test_enrich_text_degrades_when_projection_surfaces_missing(monkeypatch, tmp_path):
+    fake_root = tmp_path / "SensibLaw"
+    _write(fake_root / "src" / "sensiblaw" / "__init__.py", "")
+    _write(fake_root / "src" / "sensiblaw" / "interfaces" / "__init__.py", "")
+    _write(
+        fake_root / "src" / "sensiblaw" / "interfaces" / "shared_reducer.py",
+        """
+def get_canonical_tokenizer_profile_receipt():
+    return {"profile_id": "fake"}
+
+def tokenize_canonical_with_spans(text):
+    return [("hello", 0, 5)]
+
+def collect_canonical_lexeme_refs(text):
+    return [{"occurrence_id": "abc"}]
+
+def collect_canonical_structure_occurrences(text):
+    return []
+
+def collect_canonical_relational_bundle(text):
+    return {"version": "relational_bundle_v1", "canonical_text": text, "atoms": [], "relations": []}
+""",
+    )
+
+    itir._load_enrichment.cache_clear()
+    for module_name in list(sys.modules):
+        if module_name == "sensiblaw" or module_name.startswith("sensiblaw."):
+            sys.modules.pop(module_name, None)
+    monkeypatch.setenv("MYCHATARCHIVE_ITIR_PATHS", str(fake_root))
+    payload = itir.enrich_text("hello")
+
+    assert payload is not None
+    assert payload["surface"] == "sensiblaw.interfaces.shared_reducer"
+    assert payload["relational_bundle"]["version"] == "relational_bundle_v1"
+    assert payload["predicate_projection_error"] == "RuntimeError"
+    assert "predicate_projection" not in payload
 
 
 def test_enrich_text_raises_when_missing(monkeypatch, tmp_path):

--- a/tests/test_mcp_provenance_retrieval.py
+++ b/tests/test_mcp_provenance_retrieval.py
@@ -1,0 +1,362 @@
+"""Tests for provenance/governance-aware retrieval explanations."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+import pytest
+
+from mychatarchive import db
+from mychatarchive.config import get_embedding_dim
+from mychatarchive.retrieval_explain import build_provenance_ranked_chunk_results
+
+
+@pytest.fixture
+def provenance_db():
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        db_path = Path(f.name)
+    con = db.get_connection(db_path)
+    db.ensure_schema(con)
+    yield con, db_path
+    con.close()
+    db_path.unlink(missing_ok=True)
+
+
+def _vec(value: float) -> list[float]:
+    return [value] * get_embedding_dim()
+
+
+def _seed_two_messages(con) -> None:
+    predicate_projection = {
+        "version": "itir_predicate_projection_v1",
+        "predicates": [
+            {
+                "ref": "pred:1",
+                "predicate": "pay",
+                "structural_signature": "pay",
+                "roles": [
+                    {"name": "subject", "value": "tenant"},
+                    {"name": "object", "value": "rent"},
+                ],
+                "polarity": "positive",
+                "modality": "must",
+                "provenance_refs": ["pred:1"],
+                "source_spans": [{"start": 0, "end": 5, "ref": "head:0-5"}],
+                "wrapper": {"status": "structural_projection", "evidence_only": True},
+            }
+        ],
+    }
+    db.insert_message(
+        con, "msg_prov", "thread_prov", "chatgpt", "main",
+        "2026-01-01T00:00:00Z", "assistant", "Provenance rich answer", "Provenance",
+        "src_prov", "upstream-thread-1", "upstream-msg-1",
+        {
+            "itir": {
+                "tokenizer_profile_receipt": {"profile_id": "deterministic-legal"},
+                "relational_bundle": {"version": "relational_bundle_v1"},
+                "predicate_projection": predicate_projection,
+            }
+        },
+        source_path="/exports/chatgpt/export-a.json",
+        source_bucket="chatgpt_export",
+        provenance_json={"root_import_id": "imp-1"},
+    )
+    db.insert_chunk(
+        con, "chunk_prov", "msg_prov", "thread_prov", 0, "Provenance rich answer",
+        "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", _vec(0.10),
+        {"role": "assistant", "itir": {"tokenizer_profile_receipt": {"profile_id": "deterministic-legal"}}},
+    )
+
+    db.insert_message_block(
+        con,
+        block_id="blk-1",
+        message_id="msg_prov",
+        canonical_thread_id="thread_prov",
+        block_index=0,
+        block_type="text",
+        text="Provenance rich answer",
+        source_path="/exports/chatgpt/export-a.json",
+        source_bucket="chatgpt_export",
+        provenance_json={"span": [0, 21]},
+    )
+    db.insert_provenance_ref(
+        con,
+        provenance_ref_id="pref-1",
+        message_id="msg_prov",
+        block_id="blk-1",
+        ref_index=0,
+        source_id="src_prov",
+        source_thread_id="upstream-thread-1",
+        source_message_id="upstream-msg-1",
+        source_path="/exports/chatgpt/export-a.json",
+        source_bucket="chatgpt_export",
+        locator_json={"line": 12},
+    )
+    db.insert_predicate_projection(con, "msg_prov", "thread_prov", predicate_projection)
+
+    db.insert_message(
+        con, "msg_plain", "thread_plain", "chatgpt", "main",
+        "2026-01-01T00:00:01Z", "assistant", "Semantically strong but weak provenance",
+        "Plain", "src_plain",
+    )
+    db.insert_chunk(
+        con, "chunk_plain", "msg_plain", "thread_plain", 0,
+        "Semantically strong but weak provenance",
+        "2026-01-01T00:00:01Z", "2026-01-01T00:00:01Z", _vec(0.12),
+        {"role": "assistant"},
+    )
+    con.commit()
+
+
+def test_provenance_ranker_can_promote_governed_results(provenance_db):
+    con, _ = provenance_db
+    _seed_two_messages(con)
+
+    semantic_matches = [
+        ("chunk_plain", 0.01),  # higher semantic similarity
+        ("chunk_prov", 0.35),   # lower semantic similarity, much stronger provenance
+    ]
+    ranked = build_provenance_ranked_chunk_results(
+        con,
+        semantic_matches,
+        limit=2,
+        governance_weight=0.50,
+        rerank_by_governance=True,
+    )
+
+    assert [row["chunk_id"] for row in ranked] == ["chunk_prov", "chunk_plain"]
+    assert ranked[0]["schema"] == "mychatarchive.semantic_result.v1"
+    assert ranked[0]["result_type"] == "message_chunk"
+    assert ranked[0]["source_db"].endswith(".sqlite")
+    assert ranked[0]["canonical_thread_id"] == "thread_prov"
+    assert ranked[0]["thread_id"] == "thread_prov"
+    assert ranked[0]["message_id"] == "msg_prov"
+    assert ranked[0]["source_thread_id"] == "upstream-thread-1"
+    assert ranked[0]["source_message_id"] == "upstream-msg-1"
+    assert ranked[0]["timestamp_start"] == "2026-01-01T00:00:00Z"
+    assert ranked[0]["timestamp_end"] == "2026-01-01T00:00:00Z"
+    assert ranked[0]["excerpt"] == "Provenance rich answer"
+    assert ranked[0]["scores"]["semantic_distance"] == pytest.approx(0.35)
+    assert ranked[0]["scores"]["rank_score"] == ranked[0]["rank_score"]
+    assert ranked[0]["provenance"]["canonical_thread_id"] == "thread_prov"
+    assert ranked[0]["provenance"]["chunk_id"] == "chunk_prov"
+    assert ranked[0]["provenance"]["source_id"] == "src_prov"
+    assert ranked[0]["provenance"]["source_path"] == "/exports/chatgpt/export-a.json"
+    assert ranked[0]["provenance"]["provenance_json"] == {"root_import_id": "imp-1"}
+    assert ranked[0]["governance"]["tier"] == "high"
+    assert "provenance_refs=1" in ranked[0]["governance"]["signals"]
+    assert "predicate_refs=1" in ranked[0]["governance"]["signals"]
+    assert ranked[0]["governance"]["itir"]["tokenizer_profile_id"] == "deterministic-legal"
+    assert ranked[0]["rank_score"] > ranked[1]["rank_score"]
+
+
+def test_provenance_ranker_surfaces_predicate_residuals(provenance_db):
+    con, _ = provenance_db
+    _seed_two_messages(con)
+
+    semantic_matches = [("chunk_prov", 0.20)]
+    query_projection = {
+        "version": "itir_predicate_projection_v1",
+        "predicates": [
+            {
+                "ref": "query:1",
+                "predicate": "pay",
+                "structural_signature": "pay",
+                "roles": [
+                    {"name": "subject", "value": "tenant"},
+                    {"name": "object", "value": "rent"},
+                ],
+                "polarity": "positive",
+            }
+        ],
+    }
+    ranked = build_provenance_ranked_chunk_results(
+        con,
+        semantic_matches,
+        limit=1,
+        governance_weight=0.30,
+        rerank_by_governance=True,
+        query_projection=query_projection,
+    )
+
+    assert ranked[0]["governance"]["predicate_residual"]["available"] is True
+    assert ranked[0]["governance"]["predicate_residual"]["shared_predicates"] == ["pay"]
+    assert ranked[0]["governance"]["predicate_residual"]["contradictions"] == []
+
+
+def test_provenance_result_warns_instead_of_fabricating_missing_ids(provenance_db):
+    con, _ = provenance_db
+    db.insert_chunk(
+        con, "chunk_orphan", None, "thread_orphan", 0,
+        "Chunk without a source message",
+        "2026-01-01T00:00:02Z", "2026-01-01T00:00:02Z", _vec(0.13),
+        {"role": "assistant"},
+    )
+    con.commit()
+
+    ranked = build_provenance_ranked_chunk_results(
+        con,
+        [("chunk_orphan", 0.05)],
+        limit=1,
+    )
+
+    assert ranked[0]["message_id"] is None
+    assert ranked[0]["canonical_thread_id"] == "thread_orphan"
+    assert ranked[0]["provenance"]["message_id"] is None
+    assert ranked[0]["scores"]["semantic_distance"] == pytest.approx(0.05)
+    assert ranked[0]["warnings"][0]["code"] == "semantic_result_missing_provenance"
+    assert "message_id" in ranked[0]["warnings"][0]["missing_fields"]
+    assert "provenance.canonical_thread_id" not in ranked[0]["warnings"][0]["missing_fields"]
+
+
+def test_search_brain_governed_returns_explanation_payload(monkeypatch, provenance_db):
+    con, _ = provenance_db
+    _seed_two_messages(con)
+
+    class _DummyFastMCP:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def tool(self):
+            def _decorator(fn):
+                return fn
+            return _decorator
+
+        def run(self, *_args, **_kwargs):
+            return None
+
+    fake_mcp = types.ModuleType("mcp")
+    fake_server_pkg = types.ModuleType("mcp.server")
+    fake_fastmcp = types.ModuleType("mcp.server.fastmcp")
+    fake_fastmcp.FastMCP = _DummyFastMCP
+
+    monkeypatch.setitem(sys.modules, "mcp", fake_mcp)
+    monkeypatch.setitem(sys.modules, "mcp.server", fake_server_pkg)
+    monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", fake_fastmcp)
+
+    from mychatarchive.mcp import server
+
+    monkeypatch.setattr(server, "_get_con", lambda: con)
+    monkeypatch.setattr(server, "_lazy_embed", lambda _query: _vec(0.2))
+    monkeypatch.setattr(
+        server,
+        "enrich_text_with_itir",
+        lambda _query: {
+            "predicate_projection": {
+                "version": "itir_predicate_projection_v1",
+                "predicates": [
+                    {
+                        "ref": "query:1",
+                        "predicate": "pay",
+                        "structural_signature": "pay",
+                        "roles": [
+                            {"name": "subject", "value": "tenant"},
+                            {"name": "object", "value": "rent"},
+                        ],
+                        "polarity": "positive",
+                    }
+                ],
+            }
+        },
+    )
+    monkeypatch.setattr(
+        db,
+        "search_chunks",
+        lambda *_args, **_kwargs: [("chunk_plain", 0.01), ("chunk_prov", 0.35)],
+    )
+
+    payload = json.loads(
+        server.search_brain_governed(
+            "governed retrieval",
+            limit=2,
+            rerank_by_governance=True,
+            governance_weight=0.50,
+        )
+    )
+
+    assert payload["count"] == 2
+    assert payload["scoring"]["governance_weight"] == 0.5
+    assert payload["results"][0]["chunk_id"] == "chunk_prov"
+    assert payload["results"][0]["governance"]["source"]["source_path"] == (
+        "/exports/chatgpt/export-a.json"
+    )
+    assert payload["results"][0]["governance"]["evidence_counts"]["provenance_refs"] == 1
+    assert payload["results"][0]["governance"]["evidence_counts"]["predicate_refs"] == 1
+    assert payload["results"][0]["governance"]["predicate_residual"]["shared_predicates"] == ["pay"]
+
+
+def test_search_brain_governed_can_surface_predicate_only_candidates(monkeypatch, provenance_db):
+    con, _ = provenance_db
+    _seed_two_messages(con)
+
+    class _DummyFastMCP:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def tool(self):
+            def _decorator(fn):
+                return fn
+            return _decorator
+
+        def run(self, *_args, **_kwargs):
+            return None
+
+    fake_mcp = types.ModuleType("mcp")
+    fake_server_pkg = types.ModuleType("mcp.server")
+    fake_fastmcp = types.ModuleType("mcp.server.fastmcp")
+    fake_fastmcp.FastMCP = _DummyFastMCP
+
+    monkeypatch.setitem(sys.modules, "mcp", fake_mcp)
+    monkeypatch.setitem(sys.modules, "mcp.server", fake_server_pkg)
+    monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", fake_fastmcp)
+
+    from mychatarchive.mcp import server
+
+    monkeypatch.setattr(server, "_get_con", lambda: con)
+    monkeypatch.setattr(server, "_lazy_embed", lambda _query: _vec(0.2))
+    monkeypatch.setattr(
+        server,
+        "enrich_text_with_itir",
+        lambda _query: {
+            "predicate_projection": {
+                "version": "itir_predicate_projection_v1",
+                "predicates": [
+                    {
+                        "ref": "query:1",
+                        "predicate": "pay",
+                        "structural_signature": "pay",
+                        "roles": [
+                            {"name": "subject", "value": "tenant"},
+                            {"name": "object", "value": "rent"},
+                        ],
+                        "polarity": "positive",
+                    }
+                ],
+            }
+        },
+    )
+    monkeypatch.setattr(
+        db,
+        "search_chunks",
+        lambda *_args, **_kwargs: [],
+    )
+
+    payload = json.loads(
+        server.search_brain_governed(
+            "tenant must pay rent",
+            limit=2,
+            rerank_by_governance=True,
+            governance_weight=0.30,
+        )
+    )
+
+    assert payload["count"] == 1
+    assert payload["scoring"]["predicate_candidates"] == 1
+    assert payload["results"][0]["chunk_id"] == "chunk_prov"
+    assert payload["results"][0]["semantic_similarity"] == 0.0
+    assert payload["results"][0]["predicate_similarity"] > 0.0
+    assert "predicate_candidate_matches=pay" in payload["results"][0]["governance"]["signals"]

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import mychatarchive.parsers as parser_registry
 from mychatarchive.parsers import detect_format, parse
 
 EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
@@ -44,3 +45,33 @@ def test_parse_grok():
 def test_auto_detect_parse():
     messages = list(parse(EXAMPLES_DIR / "sample_chatgpt.json"))
     assert len(messages) > 0
+
+
+def test_parse_preserves_optional_archive_truth_fields(monkeypatch, tmp_path):
+    class StubParser:
+        @staticmethod
+        def parse(_input_path):
+            yield {
+                "thread_id": "thread-1",
+                "role": "user",
+                "content": "hello",
+                "created_at": 1700000000.0,
+                "source_path": "/exports/chatgpt.json",
+                "source_bucket": "dropbox",
+                "provenance_json": {"origin": "test"},
+                "content_blocks": [{"kind": "text", "text": "hello"}],
+                "provenance_refs": [{"type": "file", "id": "x1"}],
+            }
+
+    monkeypatch.setitem(parser_registry.PARSERS, "stub_format", StubParser)
+    messages = list(parse(tmp_path / "stub.json", "stub_format"))
+
+    assert len(messages) == 1
+    msg = messages[0]
+    assert msg["source_path"] == "/exports/chatgpt.json"
+    assert msg["source_bucket"] == "dropbox"
+    assert msg["provenance_json"] == {"origin": "test"}
+    assert msg["content_blocks"] == [{"kind": "text", "text": "hello"}]
+    assert msg["provenance_refs"] == [{"type": "file", "id": "x1"}]
+    assert msg["thread_title"] == ""
+    assert msg["source_message_id"] == ""


### PR DESCRIPTION
## Summary

Adds the existing ITIR/live-source enrichment work plus a canonical archive bridge for MyChatArchive vector and hybrid retrieval.

## What changed

- Adds required local ITIR shared-reducer enrichment on ingest with configurable local path resolution.
- Adds provenance-aware ingest plus DB-first live ChatGPT selector resolution with provider fallback.
- Adds NotebookLM pack/ingest CLI surfaces and preserves upstream ChatGPT message IDs.
- Tightens the SQLite ingest hot path by using insert cursor rowids for FTS doc mapping and ingest-friendly pragmas.
- Imports canonical archive message rows into MCA while preserving `canonical_thread_id`, `source_thread_id`, `source_message_id`, role, title, timestamp, platform, account, and provenance.
- Adds provenance-rich semantic result shaping and hybrid FTS/vector result merging over shared canonical IDs.
- Extends SQLite storage and DB helpers for message blocks, provenance refs, predicate projections, and retrieval explanations.
- Documents the ITIR-native transition and the rule that vectors attach to canonical rows, not generated Markdown sidecars.

## Why

The archive source of truth should remain canonical message/thread rows. Vector search should be a retrieval index over those stable IDs so agents can resolve semantic hits back to exact archive provenance. This also gives ITIR/robust-context-fetch a clean path from `/home/c/chat_archive.sqlite` into MCA's local SQLite/vector stack without making Markdown sidecars the source of truth.

## Validation

- `PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_ingest_bridge.py tests/test_hybrid_search.py tests/test_mcp_provenance_retrieval.py tests/test_db.py tests/test_itir.py tests/test_parsers.py` -> 34 passed

## Known limits

- Live embedding generation against a large real archive still needs an operator run with the local model cache and target DB, e.g. `/home/c/chat_archive_mca.sqlite`.
- The branch intentionally keeps external ITIR/reverse-engineered-chatgpt repos as local dependencies; it does not vendor those projects.