### PR TITLE
Fix groups subcommands crashing on missing args.db

### DIFF
--- a/src/mychatarchive/cli.py
+++ b/src/mychatarchive/cli.py
@@ -293,7 +293,7 @@ def main():
         _cmd_sources(args)
         return
 
-    db_path = args.db or get_db_path()
+    db_path = getattr(args, "db", None) or get_db_path()
 
     if args.command == "sync":
         _cmd_sync(args, db_path)


### PR DESCRIPTION
Fixes #10.

`main()` runs `db_path = args.db or get_db_path()` for every command that isn't an early return, but the `groups` subparser (and its sub-subcommands) never declare `--db`. So any `groups` invocation raised `AttributeError: 'Namespace' object has no attribute 'db'` before routing ever reached `_cmd_groups`.

One-line fix — fall back to the default DB path when `--db` isn't set:

```python
db_path = getattr(args, "db", None) or get_db_path()
```

Tested locally against a real archive (~14k messages): `groups list`, `show`, `create`, and `delete` all work now; before, every one crashed immediately.