### PR TITLE
Sensitivity classification: public / private / sealed (v0.4.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md
+
+Local-first AI memory archive. Import AI chat history, embed locally, serve via MCP.
+
+## Commands
+
+```bash
+pip install -e ".[dev]"    # install (editable)
+pytest                     # run tests
+ruff check src/ tests/     # lint (py310, line-length 100)
+```
+
+## Privacy
+
+Never include real archive statistics (sizes, counts, date spans), real
+category keywords, personal workflow details, or machine paths in code,
+comments, tests, docs, or PR text. All examples synthetic (project-x style).
+Audit PR text against this before opening.
+
+## Conventions
+
+- Conventional-commit prefixes (`feat(storage):`, `fix:`, `docs:`); release
+  branches `release/vX.Y.Z`; squash-merge only.
+- HISTORY.md is the changelog — narrative prose, one bold-dated paragraph per
+  release, honest about behavior changes.
+- Version lives in `src/mychatarchive/__init__.py` and `pyproject.toml`
+  (bump both together). Schema version in `backends/storage/sqlite.py`.
+- All schema DDL lives in `backends/storage/sqlite.py`; migrations are
+  detection-based (PRAGMA table_info / sqlite_master), idempotent, and run
+  inside `ensure_schema`. Destructive migrations back up first.
+- Every content-returning storage function takes keyword-only
+  `scope: tuple = ("public",)` — fail-closed sensitivity filtering. New
+  retrieval paths must enforce scope; sealed must remain unreachable via MCP.
+- CLI handlers: heavy imports function-local, errors to stderr + exit 1,
+  results to stdout, `_add_db_arg` on every db-touching subparser leaf.
+- `_cmd_init` rebuilds config.json from a whitelist dict — new top-level
+  config keys must be added there or `init` silently deletes them.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -37,7 +37,7 @@ the core install (import, full-text search, MCP) is now light enough for
 `uvx mychatarchive`. Existing v0.2.0 archives migrate in place on first
 open.
 
-**v0.4.0 — the archive learns to keep secrets.** An archive that holds six
+**v0.4.0 — the archive learns to keep secrets.** An archive that holds
 years of everything is only safe to connect to agents if it can withhold
 things. This release adds three sensitivity levels — public, private,
 sealed — enforced in the data access layer with a fail-closed default: any

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -36,3 +36,18 @@ torch/sentence-transformers stack moved to an optional `[local]` extra —
 the core install (import, full-text search, MCP) is now light enough for
 `uvx mychatarchive`. Existing v0.2.0 archives migrate in place on first
 open.
+
+**v0.4.0 — the archive learns to keep secrets.** An archive that holds six
+years of everything is only safe to connect to agents if it can withhold
+things. This release adds three sensitivity levels — public, private,
+sealed — enforced in the data access layer with a fail-closed default: any
+retrieval call that doesn't name a scope gets public content only, and
+sealed content cannot be expressed or returned through the MCP server at
+all. Behavior change to know about: `search` and `export` now return
+public content only unless you pass `--include-private`/`--include-sealed`
+(before this release there was no distinction, so nothing is hidden that
+you didn't classify yourself). The migration ALTERs a populated database in
+place, so it takes a verified backup first (`*.pre-v3-*.backup.sqlite`
+beside the archive) and refuses to run without one. Deliberately not in
+this release: model-assisted auto-classification and encryption at rest —
+both worth doing, neither belongs in the same change as a schema migration.

--- a/README.md
+++ b/README.md
@@ -221,6 +221,47 @@ The `group` filter works on `search_brain`, `get_context`, `get_profile`, and th
 
 ---
 
+## Sensitivity Levels
+
+Six years of chat history contains things an agent should not surface on any random turn -- medical conversations, personal spirals, private notes. Classify threads into three levels and the archive enforces them in the data access layer:
+
+| Level | Behavior |
+|-------|----------|
+| `public` | Default. Returned by every search and MCP tool. |
+| `private` | Returned only when a caller explicitly opts in (`include_private` on MCP tools, `--include-private` on the CLI). |
+| `sealed` | **Never returned by the MCP server, under any circumstances.** CLI-only, and only with an explicit `--include-sealed` flag. |
+
+```bash
+# See where you stand
+mychatarchive classify --list
+
+# Classify one thread (applies immediately)
+mychatarchive classify --thread <id> --level private
+
+# Bulk-classify by keyword -- previews first, applies only with --confirm
+mychatarchive classify --query "medical" --level sealed
+mychatarchive classify --query "medical" --level sealed --confirm
+
+# Bulk-classify old threads (last message before a date)
+mychatarchive classify --before 2022-01-01 --level private --confirm
+
+# Search honors levels
+mychatarchive search "query"                    # public only
+mychatarchive search "query" --include-private
+mychatarchive search "query" --include-sealed   # prints a warning
+```
+
+Details worth knowing:
+
+- Enforcement lives in the data access layer, not in tool handlers. A retrieval call that doesn't name a scope fails closed to public -- including third-party integrations that use `mychatarchive.db` directly.
+- Bulk classification is thread-scoped: one matching message classifies the whole conversation, which is how sensitivity works in practice.
+- `mychatarchive summarize` (the one command that sends content to an external LLM API) summarizes public threads only by default; `--include-private` opts in, and sealed threads never leave the machine.
+- Re-running `sync` on a classified thread is safe: newly imported messages inherit the thread's level before anything can read them.
+- Existing archives migrate automatically on first use -- every row defaults to `public`, and a verified backup (`*.pre-v3-*.backup.sqlite`) is written next to the database before the schema changes.
+- Sealed content is hidden, not encrypted: the text still exists in the SQLite file, its FTS index, and its vectors. Protect the file itself with filesystem permissions. Encryption at rest is a possible future addition.
+
+---
+
 ## Search from the CLI
 
 ```bash
@@ -361,6 +402,10 @@ Named sources (NAS, custom paths)     --+              |
 | `mychatarchive groups add <group> <ids...>` | Add threads to a group |
 | `mychatarchive groups show <name>` | Show threads in a group |
 | `mychatarchive groups delete <name>` | Delete a group (threads are not deleted) |
+| `mychatarchive classify --list` | Show sensitivity counts per level |
+| `mychatarchive classify --thread <id> --level <l>` | Classify a thread (public/private/sealed) |
+| `mychatarchive classify --query <text> --level <l> --confirm` | Bulk-classify threads by keyword |
+| `mychatarchive classify --before <date> --level <l> --confirm` | Bulk-classify threads by age |
 | `mychatarchive embed` | Generate vector embeddings |
 | `mychatarchive export <output>` | Export to JSON, CSV, or SQLite copy |
 | `mychatarchive serve` | Start MCP server |
@@ -447,6 +492,7 @@ Override with `--db /path/to/your.db` on any command, or set a custom drop folde
 - [x] Export (JSON, CSV, SQLite copy)
 - [x] SSE transport for remote MCP access
 - [x] One-command sync with auto-discovery + drop folder + named sources
+- [x] Sensitivity levels: public / private / sealed with fail-closed retrieval (`mychatarchive classify`)
 - [ ] Additional parsers (Gemini, Perplexity, Copilot)
 - [ ] Grouping UI (browse threads and assign to groups without knowing thread IDs)
 - [ ] Analysis engine (deep prompts against your full archive)

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The `group` filter works on `search_brain`, `get_context`, `get_profile`, and th
 
 ## Sensitivity Levels
 
-Six years of chat history contains things an agent should not surface on any random turn -- medical conversations, personal spirals, private notes. Classify threads into three levels and the archive enforces them in the data access layer:
+Years of chat history contain things an agent should not surface on any random turn -- sensitive work, personal matters, private notes. Classify threads into three levels and the archive enforces them in the data access layer:
 
 | Level | Behavior |
 |-------|----------|
@@ -239,8 +239,8 @@ mychatarchive classify --list
 mychatarchive classify --thread <id> --level private
 
 # Bulk-classify by keyword -- previews first, applies only with --confirm
-mychatarchive classify --query "medical" --level sealed
-mychatarchive classify --query "medical" --level sealed --confirm
+mychatarchive classify --query "project-x" --level sealed
+mychatarchive classify --query "project-x" --level sealed --confirm
 
 # Bulk-classify old threads (last message before a date)
 mychatarchive classify --before 2022-01-01 --level private --confirm

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,7 +82,7 @@ A personal AI memory system that compounds from daily usage. Start with searchab
 **Goal:** The AI has your full context -- memory, calendar, projects, patterns -- and acts on it.
 
 - [ ] Read/write loop: MCP-connected conversations auto-capture back to archive
-- [ ] Privacy flags (private vs work-safe)
+- [x] Sensitivity levels: public / private / sealed, fail-closed retrieval (`mychatarchive classify`, v0.4.0)
 - [ ] Calendar integration (MCP server or direct)
 - [ ] Project context linking (connect archive threads to repos/projects)
 - [ ] Proactive context surfacing (AI suggests relevant history before you ask)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@
 
 | Version | Supported          |
 |---------|--------------------|
+| 0.4.x   | Yes                |
 | 0.3.x   | Yes                |
 | < 0.3   | No — upgrade; archives migrate in place on first open |
 
@@ -42,6 +43,17 @@ MyChatArchive is a local-first tool. The primary attack surface includes:
   forwards archive content — including MCP clients and LLMs consuming search
   results — is a trust boundary: imported text can contain adversarial
   instructions aimed at whatever reads it.
+- **Sensitivity levels are access control, not encryption.** As of v0.4.0,
+  content can be classified public / private / sealed. Enforcement happens in
+  the data access layer and fails closed to public; sealed content cannot be
+  expressed or retrieved through the MCP server at all, and `summarize` never
+  sends sealed (or, by default, private) content to an external API. The
+  limits: sealed text still exists unencrypted in the SQLite file, its FTS
+  index, and its vector tables, and `export --format sqlite` copies the whole
+  file (it is refused when sealed rows exist unless explicitly overridden).
+  Filesystem permissions on the database remain the control that matters.
+  If you believe you have found a path that returns sealed content through
+  the MCP server, report it as a vulnerability.
 
 ## Best Practices
 

--- a/docs/nas-setup.md
+++ b/docs/nas-setup.md
@@ -177,6 +177,41 @@ Note: Claude mobile's Connectors require OAuth. On the same home WiFi (no VPN ne
 
 ---
 
+## Upgrading: sensitivity migration (v0.4.0)
+
+v0.4.0 adds a `sensitivity` column to every content table. The migration runs
+automatically on first open, takes a verified backup first, and is idempotent —
+but on a production NAS archive, run it deliberately rather than letting the
+server trigger it mid-request:
+
+```bash
+# 1. Stop the server
+kill $(cat /volume1/Knowledgebase/mychatarchive/mychatarchive.pid)
+
+# 2. Pull the new version
+cd /volume1/Knowledgebase/mychatarchive/app && git pull && pip3 install -e ".[dev]"
+
+# 3. Trigger the migration explicitly (any command that opens the db works;
+#    this one also shows you the resulting counts)
+mychatarchive classify --list --db /volume1/Knowledgebase/mychatarchive/archive.db
+
+# 4. Verify the automatic backup exists next to the archive
+ls -lh /volume1/Knowledgebase/mychatarchive/archive.pre-v3-*.backup.sqlite
+
+# 5. Restart
+/volume1/Knowledgebase/mychatarchive/start-mcp.sh
+```
+
+Notes:
+
+- The backup is a full copy of the database, written to the same volume —
+  make sure there is enough free space (same size as `archive.db`).
+- Every existing row defaults to `public`; nothing changes behavior until you
+  classify threads.
+- Once verified, the `*.backup.sqlite` file can be moved elsewhere or deleted.
+
+---
+
 ## Cert renewal
 
 mkcert certs are valid ~2 years. When they expire:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mychatarchive"
-version = "0.3.0"
+version = "0.4.0"
 description = "Local-first AI memory archive. Import chat history, generate semantic embeddings, and search via MCP."
 readme = "README.md"
 license = {text = "AGPL-3.0"}

--- a/src/mychatarchive/__init__.py
+++ b/src/mychatarchive/__init__.py
@@ -1,3 +1,3 @@
 """MyChatArchive -- Local-first AI memory archive."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/src/mychatarchive/backends/storage/__init__.py
+++ b/src/mychatarchive/backends/storage/__init__.py
@@ -2,6 +2,11 @@
 
 Any storage backend must implement these functions as module-level callables.
 The default is 'sqlite' which uses SQLite + sqlite-vec.
+
+Sensitivity scope: every content-returning function takes a keyword-only
+``scope`` tuple of sensitivity levels and must return only rows whose
+sensitivity is in that scope. The default is ``("public",)`` — a caller that
+omits scope fails closed to public. Valid levels: public, private, sealed.
 """
 
 from __future__ import annotations
@@ -10,6 +15,9 @@ from typing import TYPE_CHECKING, Iterator, Optional, Protocol, runtime_checkabl
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+SENSITIVITY_LEVELS = ("public", "private", "sealed")
+DEFAULT_SCOPE = ("public",)
 
 
 @runtime_checkable
@@ -35,29 +43,99 @@ class StorageBackend(Protocol):
     def platform_counts(self, con) -> list[tuple[str, int]]: ...
 
     # Iterators
-    def iter_messages(self, con, batch_size: int = 1000) -> Iterator[dict]: ...
+    def iter_messages(
+        self, con, batch_size: int = 1000, *, scope: tuple = DEFAULT_SCOPE,
+    ) -> Iterator[dict]: ...
     def embedded_message_ids(self, con) -> set[str]: ...
+    def iter_threads(self, con, *, scope: tuple = DEFAULT_SCOPE) -> Iterator[dict]: ...
+    def get_thread_messages(
+        self, con, canonical_thread_id: str, *, scope: tuple = DEFAULT_SCOPE,
+    ) -> list[dict]: ...
 
     # Chunks & thoughts
     def insert_chunk(
         self, con, chunk_id: str, message_id: Optional[str],
         thread_id: str, chunk_index: int, text: str,
         ts_start: str, ts_end: str, embedding: list[float],
-        meta: Optional[dict] = None,
+        meta: Optional[dict] = None, *, sensitivity: str = "public",
     ) -> None: ...
 
     def insert_thought(
         self, con, thought_id: str, text: str, created_at: str,
         embedding: list[float], meta: Optional[dict] = None,
+        *, sensitivity: str = "public",
     ) -> None: ...
 
     # Search
-    def search_chunks(self, con, embedding: list[float], limit: int = 10) -> list: ...
-    def search_thoughts(self, con, embedding: list[float], limit: int = 10) -> list: ...
-    def fts_search(self, con, query: str, limit: int = 20) -> list: ...
+    def search_chunks(
+        self, con, embedding: list[float], limit: int = 10,
+        platform: str | list[str] | None = None,
+        cutoff_iso: str | None = None,
+        sort_by_time: bool = False,
+        group_thread_ids: set[str] | None = None,
+        *, scope: tuple = DEFAULT_SCOPE,
+    ) -> list: ...
+    def search_thoughts(
+        self, con, embedding: list[float], limit: int = 10,
+        *, scope: tuple = DEFAULT_SCOPE,
+    ) -> list: ...
+    def fts_search(
+        self, con, query: str, limit: int = 20,
+        platform: str | list[str] | None = None,
+        cutoff_iso: str | None = None,
+        sort_by_time: bool = False,
+        group_thread_ids: set[str] | None = None,
+        *, scope: tuple = DEFAULT_SCOPE,
+    ) -> list: ...
+    def search_thread_summaries(
+        self, con, embedding: list[float], limit: int = 10,
+        *, scope: tuple = DEFAULT_SCOPE,
+    ) -> list: ...
 
     # Retrieval
-    def get_recent_chunks(self, con, cutoff_iso: str, limit: int = 20) -> list: ...
-    def get_recent_thoughts(self, con, cutoff_iso: str, limit: int = 20) -> list: ...
-    def get_chunk_by_id(self, con, chunk_id: str): ...
-    def get_thought_by_id(self, con, thought_id: str): ...
+    def get_recent_chunks(
+        self, con, cutoff_iso: str, limit: int = 20,
+        platform: str | list[str] | None = None,
+        *, scope: tuple = DEFAULT_SCOPE,
+    ) -> list: ...
+    def get_recent_thoughts(
+        self, con, cutoff_iso: str, limit: int = 20,
+        *, scope: tuple = DEFAULT_SCOPE,
+    ) -> list: ...
+    def get_chunk_by_id(self, con, chunk_id: str, *, scope: tuple = DEFAULT_SCOPE): ...
+    def get_thought_by_id(self, con, thought_id: str, *, scope: tuple = DEFAULT_SCOPE): ...
+
+    # Export
+    def export_messages(
+        self, con, platform: Optional[str] = None, limit: Optional[int] = None,
+        *, scope: tuple = DEFAULT_SCOPE,
+    ) -> list[dict]: ...
+    def export_thoughts(self, con, *, scope: tuple = DEFAULT_SCOPE) -> list[dict]: ...
+
+    # Thread summaries
+    def get_thread_summary(
+        self, con, canonical_thread_id: str, *, scope: tuple = DEFAULT_SCOPE,
+    ): ...
+    def get_thread_summaries(
+        self, con, canonical_thread_id: str, *, scope: tuple = DEFAULT_SCOPE,
+    ) -> list: ...
+    def get_summary_by_id(self, con, summary_id: str, *, scope: tuple = DEFAULT_SCOPE): ...
+    def list_thread_summaries(
+        self, con, limit: int = 100,
+        platform: str | list[str] | None = None,
+        since_iso: Optional[str] = None,
+        *, scope: tuple = DEFAULT_SCOPE,
+    ) -> list: ...
+
+    # Groups (thread metadata reads honor scope; membership admin does not)
+    def get_threads_in_group(
+        self, con, group_id: str, *, scope: tuple = DEFAULT_SCOPE,
+    ) -> list[dict]: ...
+
+    # Sensitivity classification
+    def set_thread_sensitivity(self, con, thread_ids: list[str], level: str) -> dict: ...
+    def get_thread_sensitivity(self, con, canonical_thread_id: str): ...
+    def sensitivity_counts(self, con) -> dict: ...
+    def sealed_exists(self, con) -> bool: ...
+    def threads_before(self, con, cutoff_iso: str) -> list[str]: ...
+    def reconcile_thread_sensitivity(self, con) -> int: ...

--- a/src/mychatarchive/backends/storage/sqlite.py
+++ b/src/mychatarchive/backends/storage/sqlite.py
@@ -3,6 +3,7 @@
 All data lives in a single .sqlite file with FTS5 and vector search via sqlite-vec.
 """
 
+import datetime
 import json
 import re
 import struct
@@ -24,6 +25,44 @@ def _get_embedding_dim() -> int:
 
 def serialize_f32(vec: list[float]) -> bytes:
     return struct.pack(f"{len(vec)}f", *vec)
+
+
+# Sensitivity levels, least to most restricted. Rows default to 'public';
+# 'private' requires callers to opt in; 'sealed' is never served over MCP.
+SENSITIVITY_LEVELS = ("public", "private", "sealed")
+
+_DEFAULT_SCOPE = ("public",)
+
+
+def _validate_scope(scope) -> tuple:
+    """Validate a sensitivity scope, returning it as a tuple.
+
+    Raises ValueError on unknown levels so a typo can never widen access.
+    """
+    scope = tuple(scope)
+    if not scope:
+        raise ValueError("sensitivity scope must not be empty")
+    unknown = [s for s in scope if s not in SENSITIVITY_LEVELS]
+    if unknown:
+        raise ValueError(
+            f"Unknown sensitivity level(s) {unknown}; valid: {list(SENSITIVITY_LEVELS)}"
+        )
+    return scope
+
+
+def _validate_level(level: str) -> str:
+    if level not in SENSITIVITY_LEVELS:
+        raise ValueError(
+            f"Unknown sensitivity level '{level}'; valid: {list(SENSITIVITY_LEVELS)}"
+        )
+    return level
+
+
+def _scope_sql(scope, column: str = "sensitivity") -> tuple[str, tuple]:
+    """Return an 'IN (?,...)' predicate + params for a validated scope."""
+    scope = _validate_scope(scope)
+    placeholders = ",".join("?" * len(scope))
+    return f"{column} IN ({placeholders})", scope
 
 
 def get_connection(db_path: Path) -> sqlite3.Connection:
@@ -66,7 +105,9 @@ def _ensure_thread_summaries_v2(con: sqlite3.Connection, dim: int) -> None:
                     key_topics TEXT,
                     summary_model TEXT NOT NULL,
                     created_at TEXT NOT NULL,
-                    updated_at TEXT NOT NULL
+                    updated_at TEXT NOT NULL,
+                    sensitivity TEXT NOT NULL DEFAULT 'public'
+                        CHECK(sensitivity IN ('public','private','sealed'))
                 );
                 INSERT INTO thread_summaries_new
                     (summary_id, canonical_thread_id, segment_index, title, platform,
@@ -98,7 +139,9 @@ def _ensure_thread_summaries_v2(con: sqlite3.Connection, dim: int) -> None:
                     key_topics TEXT,
                     summary_model TEXT NOT NULL,
                     created_at TEXT NOT NULL,
-                    updated_at TEXT NOT NULL
+                    updated_at TEXT NOT NULL,
+                    sensitivity TEXT NOT NULL DEFAULT 'public'
+                        CHECK(sensitivity IN ('public','private','sealed'))
                 )
             """)
         # Drop old vec table (wrong PK: canonical_thread_id) and recreate with summary_id
@@ -121,7 +164,7 @@ def _ensure_thread_summaries_v2(con: sqlite3.Connection, dim: int) -> None:
     con.commit()
 
 
-SCHEMA_VERSION = "2"
+SCHEMA_VERSION = "3"
 
 
 def _detect_existing_vec_dim(con: sqlite3.Connection) -> Optional[int]:
@@ -263,6 +306,76 @@ def _ensure_messages_fts_v2(con: sqlite3.Connection) -> None:
     con.commit()
 
 
+_SENSITIVITY_TABLES = ("messages", "chunks", "thoughts", "thread_summaries")
+
+
+def _ensure_sensitivity_v3(con: sqlite3.Connection) -> None:
+    """Add the sensitivity column to all content tables (schema v3). Idempotent.
+
+    On a populated archive this is the only migration that ALTERs in place, so
+    it backs the database file up first (sqlite backup API — a plain file copy
+    would drop uncommitted WAL frames) and refuses to migrate if the backup
+    cannot be verified. Fresh archives get the column from the CREATE DDL and
+    never reach the backup path.
+    """
+    missing = []
+    for table in _SENSITIVITY_TABLES:
+        cols = {row[1] for row in con.execute(f"PRAGMA table_info({table})").fetchall()}
+        if cols and "sensitivity" not in cols:
+            missing.append(table)
+
+    if missing:
+        db_file = None
+        for _, name, path in con.execute("PRAGMA database_list").fetchall():
+            if name == "main" and path:
+                db_file = Path(path)
+                break
+
+        if db_file is not None:
+            stamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+            backup_path = db_file.with_name(f"{db_file.stem}.pre-v3-{stamp}.backup.sqlite")
+            dest = sqlite3.connect(str(backup_path))
+            try:
+                con.backup(dest)
+            finally:
+                dest.close()
+            if not backup_path.exists() or backup_path.stat().st_size == 0:
+                raise RuntimeError(
+                    f"Pre-migration backup verification failed at {backup_path}; "
+                    f"refusing to migrate. Free disk space and retry."
+                )
+
+        con.commit()  # close any implicit transaction before BEGIN IMMEDIATE
+        con.execute("BEGIN IMMEDIATE")  # serialize concurrent openers (serve + CLI)
+        for table in missing:
+            cols = {row[1] for row in con.execute(f"PRAGMA table_info({table})").fetchall()}
+            if "sensitivity" in cols:
+                continue  # another process migrated while we waited on the lock
+            con.execute(f"""
+                ALTER TABLE {table} ADD COLUMN sensitivity TEXT NOT NULL DEFAULT 'public'
+                    CHECK(sensitivity IN ('public','private','sealed'))
+            """)
+        con.execute(
+            "INSERT OR REPLACE INTO archive_meta (key, value) VALUES ('schema_version', ?)",
+            (SCHEMA_VERSION,),
+        )
+        con.commit()
+
+    # Idempotent index maintenance (all paths, including fresh installs).
+    # Partial indexes: archives are overwhelmingly public, so index only the
+    # exceptions — powers sealed_exists() and classify --list cheaply.
+    for table in _SENSITIVITY_TABLES:
+        con.execute(f"""
+            CREATE INDEX IF NOT EXISTS idx_{table}_sensitivity
+            ON {table}(sensitivity) WHERE sensitivity != 'public'
+        """)
+    # Thread-level classify UPDATEs chunks by thread; chunks had no thread index.
+    con.execute(
+        "CREATE INDEX IF NOT EXISTS idx_chunks_thread ON chunks(canonical_thread_id)"
+    )
+    con.commit()
+
+
 def ensure_schema(con: sqlite3.Connection):
     """Create all tables (ingestion + brain). Idempotent.
 
@@ -283,7 +396,9 @@ def ensure_schema(con: sqlite3.Connection):
             role TEXT NOT NULL,
             text TEXT NOT NULL,
             title TEXT,
-            source_id TEXT NOT NULL
+            source_id TEXT NOT NULL,
+            sensitivity TEXT NOT NULL DEFAULT 'public'
+                CHECK(sensitivity IN ('public','private','sealed'))
         );
 
         CREATE TABLE IF NOT EXISTS chunks (
@@ -294,14 +409,18 @@ def ensure_schema(con: sqlite3.Connection):
             text TEXT NOT NULL,
             ts_start TEXT,
             ts_end TEXT,
-            meta TEXT
+            meta TEXT,
+            sensitivity TEXT NOT NULL DEFAULT 'public'
+                CHECK(sensitivity IN ('public','private','sealed'))
         );
 
         CREATE TABLE IF NOT EXISTS thoughts (
             thought_id TEXT PRIMARY KEY,
             text TEXT NOT NULL,
             created_at TEXT NOT NULL,
-            meta TEXT
+            meta TEXT,
+            sensitivity TEXT NOT NULL DEFAULT 'public'
+                CHECK(sensitivity IN ('public','private','sealed'))
         );
 
         -- User-curated thread groups (e.g. "jarvis", "coding", "projects").
@@ -356,6 +475,10 @@ def ensure_schema(con: sqlite3.Connection):
     # Thread summaries: create or migrate to multi-segment schema
     _ensure_thread_summaries_v2(con, dim)
 
+    # Sensitivity column (schema v3). MUST run last: _ensure_thread_summaries_v2
+    # table-rewrites thread_summaries and would drop a column added earlier.
+    _ensure_sensitivity_v3(con)
+
 
 # --- Ingestion ---
 
@@ -409,12 +532,14 @@ def platform_counts(con: sqlite3.Connection) -> list[tuple[str, int]]:
 
 # --- Iterators ---
 
-def iter_messages(con: sqlite3.Connection, batch_size: int = 1000):
+def iter_messages(con: sqlite3.Connection, batch_size: int = 1000, *,
+                  scope: tuple = _DEFAULT_SCOPE):
+    scope_sql, scope_params = _scope_sql(scope)
     cur = con.cursor()
-    cur.execute("""
-        SELECT message_id, canonical_thread_id, ts, role, text, title
-        FROM messages ORDER BY canonical_thread_id, ts
-    """)
+    cur.execute(f"""
+        SELECT message_id, canonical_thread_id, ts, role, text, title, sensitivity
+        FROM messages WHERE {scope_sql} ORDER BY canonical_thread_id, ts
+    """, scope_params)
     while True:
         rows = cur.fetchmany(batch_size)
         if not rows:
@@ -427,6 +552,7 @@ def iter_messages(con: sqlite3.Connection, batch_size: int = 1000):
                 "role": row[3],
                 "text": row[4],
                 "title": row[5],
+                "sensitivity": row[6],
             }
 
 
@@ -454,13 +580,14 @@ def clear_chunks(con: sqlite3.Connection) -> None:
 def insert_chunk(con: sqlite3.Connection, chunk_id: str, message_id: Optional[str],
                  thread_id: str, chunk_index: int, text: str,
                  ts_start: str, ts_end: str, embedding: list[float],
-                 meta: Optional[dict] = None):
+                 meta: Optional[dict] = None, *, sensitivity: str = "public"):
+    _validate_level(sensitivity)
     con.execute(
         "INSERT OR IGNORE INTO chunks "
-        "(chunk_id, message_id, canonical_thread_id, chunk_index, text, ts_start, ts_end, meta) "
-        "VALUES (?,?,?,?,?,?,?,?)",
+        "(chunk_id, message_id, canonical_thread_id, chunk_index, text, ts_start, ts_end, meta, "
+        "sensitivity) VALUES (?,?,?,?,?,?,?,?,?)",
         (chunk_id, message_id, thread_id, chunk_index, text, ts_start, ts_end,
-         json.dumps(meta) if meta else None),
+         json.dumps(meta) if meta else None, sensitivity),
     )
     con.execute(
         "INSERT OR IGNORE INTO vec_chunks (chunk_id, embedding) VALUES (?, ?)",
@@ -469,10 +596,13 @@ def insert_chunk(con: sqlite3.Connection, chunk_id: str, message_id: Optional[st
 
 
 def insert_thought(con: sqlite3.Connection, thought_id: str, text: str,
-                   created_at: str, embedding: list[float], meta: Optional[dict] = None):
+                   created_at: str, embedding: list[float], meta: Optional[dict] = None,
+                   *, sensitivity: str = "public"):
+    _validate_level(sensitivity)
     con.execute(
-        "INSERT OR IGNORE INTO thoughts (thought_id, text, created_at, meta) VALUES (?,?,?,?)",
-        (thought_id, text, created_at, json.dumps(meta) if meta else None),
+        "INSERT OR IGNORE INTO thoughts (thought_id, text, created_at, meta, sensitivity) "
+        "VALUES (?,?,?,?,?)",
+        (thought_id, text, created_at, json.dumps(meta) if meta else None, sensitivity),
     )
     con.execute(
         "INSERT OR IGNORE INTO vec_thoughts (thought_id, embedding) VALUES (?, ?)",
@@ -488,6 +618,8 @@ def search_chunks(
     cutoff_iso: str | None = None,
     sort_by_time: bool = False,
     group_thread_ids: set[str] | None = None,
+    *,
+    scope: tuple = _DEFAULT_SCOPE,
 ):
     # An explicit empty set means "filter to zero threads" → nothing to return.
     # Without this, bool(set()) is False, needs_filter ignores it, and we'd
@@ -495,7 +627,9 @@ def search_chunks(
     if group_thread_ids is not None and not group_thread_ids:
         return []
 
-    needs_filter = bool(platform or cutoff_iso or group_thread_ids)
+    scope = _validate_scope(scope)
+    scope_active = set(scope) != set(SENSITIVITY_LEVELS)
+    needs_filter = bool(platform or cutoff_iso or group_thread_ids) or scope_active
     # When scoping to a small set of threads, the target chunks are unlikely to appear
     # in the global top (limit * 5) results across 90k+ chunks. Use a much larger
     # candidate pool so filtering actually finds matching chunks.
@@ -538,6 +672,11 @@ def search_chunks(
         conditions.append(f"c.canonical_thread_id IN ({placeholders})")
         params.extend(group_thread_ids)
 
+    if scope_active:
+        scope_sql, scope_params = _scope_sql(scope, "c.sensitivity")
+        conditions.append(scope_sql)
+        params.extend(scope_params)
+
     join_clause = " JOIN messages m ON c.message_id = m.message_id" if need_message_join else ""
     where_sql = " AND ".join(conditions)
 
@@ -555,12 +694,31 @@ def search_chunks(
     return [(c, d) for c, ts, d in matched[:limit]]
 
 
-def search_thoughts(con: sqlite3.Connection, embedding: list[float], limit: int = 10):
-    return con.execute(
+def search_thoughts(con: sqlite3.Connection, embedding: list[float], limit: int = 10, *,
+                    scope: tuple = _DEFAULT_SCOPE):
+    scope = _validate_scope(scope)
+    scope_active = set(scope) != set(SENSITIVITY_LEVELS)
+    # vec0 can't carry filter columns: over-fetch, filter against thoughts,
+    # keep KNN distance order, truncate.
+    fetch_limit = limit * 5 if scope_active else limit
+    raw = con.execute(
         "SELECT thought_id, distance FROM vec_thoughts "
         "WHERE embedding MATCH ? AND k = ?",
-        (serialize_f32(embedding), limit),
+        (serialize_f32(embedding), fetch_limit),
     ).fetchall()
+    if not scope_active or not raw:
+        return raw[:limit]
+    ids = [r[0] for r in raw]
+    scope_sql, scope_params = _scope_sql(scope)
+    placeholders = ",".join("?" * len(ids))
+    allowed = {
+        r[0] for r in con.execute(
+            f"SELECT thought_id FROM thoughts WHERE thought_id IN ({placeholders}) "
+            f"AND {scope_sql}",
+            (*ids, *scope_params),
+        ).fetchall()
+    }
+    return [(tid, dist) for tid, dist in raw if tid in allowed][:limit]
 
 
 def _build_fts_match(query: str) -> str:
@@ -589,6 +747,8 @@ def fts_search(
     cutoff_iso: str | None = None,
     sort_by_time: bool = False,
     group_thread_ids: set[str] | None = None,
+    *,
+    scope: tuple = _DEFAULT_SCOPE,
 ):
     """Full-text search via external-content FTS5, ranked by bm25 relevance.
 
@@ -596,16 +756,21 @@ def fts_search(
     which case the caller wants reverse-chronological. The messages row is
     joined directly on the shared rowid (no docid map).
     """
+    # Explicit empty thread set means "filter to zero threads" (same guard as
+    # search_chunks — without it an unknown group silently searches everything).
+    if group_thread_ids is not None and not group_thread_ids:
+        return []
+    scope_sql, scope_params = _scope_sql(scope, "m.sensitivity")
     match = _build_fts_match(query)
     if not match:
         return []
-    sql = """
+    sql = f"""
         SELECT m.message_id, m.text, m.canonical_thread_id, m.ts, m.role, m.title
         FROM messages_fts f
         JOIN messages m ON m.rowid = f.rowid
-        WHERE messages_fts MATCH ?
+        WHERE messages_fts MATCH ? AND {scope_sql}
     """
-    params: list = [match]
+    params: list = [match, *scope_params]
     if platform:
         platforms = [platform] if isinstance(platform, str) else platform
         placeholders = ",".join("?" * len(platforms))
@@ -630,12 +795,19 @@ def get_recent_chunks(
     cutoff_iso: str,
     limit: int = 20,
     platform: str | list[str] | None = None,
+    *,
+    scope: tuple = _DEFAULT_SCOPE,
 ):
+    # Filter on the chunk's own denormalized column in BOTH branches — the
+    # no-platform branch never joins messages, so a message-side filter would
+    # silently not apply there.
+    scope_sql, scope_params = _scope_sql(scope, "sensitivity")
     if not platform:
         return con.execute(
-            "SELECT chunk_id, text, canonical_thread_id, ts_start, meta "
-            "FROM chunks WHERE ts_start >= ? ORDER BY ts_start DESC LIMIT ?",
-            (cutoff_iso, limit),
+            f"SELECT chunk_id, text, canonical_thread_id, ts_start, meta "
+            f"FROM chunks WHERE ts_start >= ? AND {scope_sql} "
+            f"ORDER BY ts_start DESC LIMIT ?",
+            (cutoff_iso, *scope_params, limit),
         ).fetchall()
 
     platforms = [platform] if isinstance(platform, str) else platform
@@ -645,62 +817,79 @@ def get_recent_chunks(
         SELECT c.chunk_id, c.text, c.canonical_thread_id, c.ts_start, c.meta
         FROM chunks c
         JOIN messages m ON c.message_id = m.message_id
-        WHERE c.ts_start >= ? AND m.platform IN ({placeholders})
+        WHERE c.ts_start >= ? AND m.platform IN ({placeholders}) AND c.{scope_sql}
         ORDER BY c.ts_start DESC LIMIT ?
         """,
-        (cutoff_iso, *platforms, limit),
+        (cutoff_iso, *platforms, *scope_params, limit),
     ).fetchall()
 
 
-def get_recent_thoughts(con: sqlite3.Connection, cutoff_iso: str, limit: int = 20):
+def get_recent_thoughts(con: sqlite3.Connection, cutoff_iso: str, limit: int = 20, *,
+                        scope: tuple = _DEFAULT_SCOPE):
+    scope_sql, scope_params = _scope_sql(scope)
     return con.execute(
-        "SELECT thought_id, text, created_at, meta "
-        "FROM thoughts WHERE created_at >= ? ORDER BY created_at DESC LIMIT ?",
-        (cutoff_iso, limit),
+        f"SELECT thought_id, text, created_at, meta "
+        f"FROM thoughts WHERE created_at >= ? AND {scope_sql} "
+        f"ORDER BY created_at DESC LIMIT ?",
+        (cutoff_iso, *scope_params, limit),
     ).fetchall()
 
 
-def get_chunk_by_id(con: sqlite3.Connection, chunk_id: str):
+def get_chunk_by_id(con: sqlite3.Connection, chunk_id: str, *,
+                    scope: tuple = _DEFAULT_SCOPE):
+    # Direct-ID lookups enforce scope too: they are reachable with no search
+    # step in front (e.g. provenance tools holding a chunk_id).
+    scope_sql, scope_params = _scope_sql(scope)
     return con.execute(
-        "SELECT text, canonical_thread_id, ts_start, ts_end, meta FROM chunks WHERE chunk_id = ?",
-        (chunk_id,),
+        f"SELECT text, canonical_thread_id, ts_start, ts_end, meta FROM chunks "
+        f"WHERE chunk_id = ? AND {scope_sql}",
+        (chunk_id, *scope_params),
     ).fetchone()
 
 
-def get_thought_by_id(con: sqlite3.Connection, thought_id: str):
+def get_thought_by_id(con: sqlite3.Connection, thought_id: str, *,
+                      scope: tuple = _DEFAULT_SCOPE):
+    scope_sql, scope_params = _scope_sql(scope)
     return con.execute(
-        "SELECT text, created_at, meta FROM thoughts WHERE thought_id = ?",
-        (thought_id,),
+        f"SELECT text, created_at, meta FROM thoughts WHERE thought_id = ? AND {scope_sql}",
+        (thought_id, *scope_params),
     ).fetchone()
 
 
 # ── Export helpers ────────────────────────────────────────────────────────────
 
 def export_messages(con: sqlite3.Connection, platform: Optional[str] = None,
-                    limit: Optional[int] = None):
-    query = """
-        SELECT message_id, canonical_thread_id, platform, account_id,
-               ts, role, text, title, source_id
-        FROM messages ORDER BY platform, canonical_thread_id, ts
-    """
-    params: list = []
+                    limit: Optional[int] = None, *, scope: tuple = _DEFAULT_SCOPE):
+    scope_sql, scope_params = _scope_sql(scope)
+    conditions = [scope_sql]
+    params: list = list(scope_params)
     if platform:
-        query = query.replace("ORDER BY", "WHERE platform = ? ORDER BY")
+        conditions.append("platform = ?")
         params.append(platform)
+    query = f"""
+        SELECT message_id, canonical_thread_id, platform, account_id,
+               ts, role, text, title, source_id, sensitivity
+        FROM messages WHERE {" AND ".join(conditions)}
+        ORDER BY platform, canonical_thread_id, ts
+    """
     if limit:
         query += " LIMIT ?"
         params.append(limit)
     rows = con.execute(query, params).fetchall()
     return [
         {"message_id": r[0], "thread_id": r[1], "platform": r[2], "account_id": r[3],
-         "timestamp": r[4], "role": r[5], "content": r[6], "title": r[7], "source_id": r[8]}
+         "timestamp": r[4], "role": r[5], "content": r[6], "title": r[7], "source_id": r[8],
+         "sensitivity": r[9]}
         for r in rows
     ]
 
 
-def export_thoughts(con: sqlite3.Connection):
+def export_thoughts(con: sqlite3.Connection, *, scope: tuple = _DEFAULT_SCOPE):
+    scope_sql, scope_params = _scope_sql(scope)
     rows = con.execute(
-        "SELECT thought_id, text, created_at, meta FROM thoughts ORDER BY created_at"
+        f"SELECT thought_id, text, created_at, meta FROM thoughts "
+        f"WHERE {scope_sql} ORDER BY created_at",
+        scope_params,
     ).fetchall()
     return [{"thought_id": r[0], "content": r[1], "created_at": r[2], "metadata": r[3]}
             for r in rows]
@@ -708,19 +897,34 @@ def export_thoughts(con: sqlite3.Connection):
 
 # ── Thread iteration + summaries ─────────────────────────────────────────────
 
-def iter_threads(con: sqlite3.Connection):
-    """Yield one dict per unique thread with metadata aggregated from messages."""
-    cur = con.execute("""
+# Numeric ranks for computing a thread's effective (max) sensitivity in SQL.
+_LEVEL_RANK_SQL = "CASE sensitivity WHEN 'sealed' THEN 2 WHEN 'private' THEN 1 ELSE 0 END"
+
+
+def iter_threads(con: sqlite3.Connection, *, scope: tuple = _DEFAULT_SCOPE):
+    """Yield one dict per unique thread with metadata aggregated from messages.
+
+    A thread is excluded if ANY of its messages is outside scope — titles and
+    aggregates leak topics, so mixed threads fail closed.
+    """
+    scope = _validate_scope(scope)
+    max_allowed_rank = max(
+        {"public": 0, "private": 1, "sealed": 2}[s] for s in scope
+    )
+    cur = con.execute(f"""
         SELECT canonical_thread_id,
                MAX(platform) AS platform,
                MAX(title) AS title,
                COUNT(*) AS message_count,
                MIN(ts) AS ts_start,
-               MAX(ts) AS ts_end
+               MAX(ts) AS ts_end,
+               MAX({_LEVEL_RANK_SQL}) AS max_rank
         FROM messages
         GROUP BY canonical_thread_id
+        HAVING max_rank <= ?
         ORDER BY ts_start ASC
-    """)
+    """, (max_allowed_rank,))
+    rank_to_level = {0: "public", 1: "private", 2: "sealed"}
     for row in cur:
         yield {
             "canonical_thread_id": row[0],
@@ -729,14 +933,18 @@ def iter_threads(con: sqlite3.Connection):
             "message_count": row[3],
             "ts_start": row[4],
             "ts_end": row[5],
+            "sensitivity": rank_to_level[row[6]],
         }
 
 
-def get_thread_messages(con: sqlite3.Connection, canonical_thread_id: str) -> list[dict]:
-    """Return all messages for a thread, ordered chronologically."""
+def get_thread_messages(con: sqlite3.Connection, canonical_thread_id: str, *,
+                        scope: tuple = _DEFAULT_SCOPE) -> list[dict]:
+    """Return all in-scope messages for a thread, ordered chronologically."""
+    scope_sql, scope_params = _scope_sql(scope)
     rows = con.execute(
-        "SELECT role, text, ts FROM messages WHERE canonical_thread_id = ? ORDER BY ts",
-        (canonical_thread_id,),
+        f"SELECT role, text, ts FROM messages "
+        f"WHERE canonical_thread_id = ? AND {scope_sql} ORDER BY ts",
+        (canonical_thread_id, *scope_params),
     ).fetchall()
     return [{"role": r[0], "text": r[1], "ts": r[2]} for r in rows]
 
@@ -774,22 +982,25 @@ def insert_thread_summary(
     key_topics: list[str],
     summary_model: str,
     now: str,
+    *,
+    sensitivity: str = "public",
 ):
     """Insert or replace a single summary segment."""
+    _validate_level(sensitivity)
     con.execute(
         """
         INSERT OR REPLACE INTO thread_summaries
             (summary_id, canonical_thread_id, segment_index, title, platform,
              message_count, segment_chars, ts_start, ts_end, summary,
-             key_topics, summary_model, created_at, updated_at)
+             key_topics, summary_model, created_at, updated_at, sensitivity)
         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,
             COALESCE((SELECT created_at FROM thread_summaries WHERE summary_id=?), ?),
-            ?)
+            ?, ?)
         """,
         (summary_id, canonical_thread_id, segment_index, title, platform,
          message_count, segment_chars, ts_start, ts_end, summary,
          json.dumps(key_topics), summary_model,
-         summary_id, now, now),
+         summary_id, now, now, sensitivity),
     )
 
 
@@ -821,71 +1032,103 @@ def delete_thread_summaries(con: sqlite3.Connection, canonical_thread_id: str) -
     return cur.rowcount
 
 
-def get_thread_summary(con: sqlite3.Connection, canonical_thread_id: str):
+def get_thread_summary(con: sqlite3.Connection, canonical_thread_id: str, *,
+                       scope: tuple = _DEFAULT_SCOPE):
     """Returns the first segment (segment_index=0) for a thread using the 10-col layout, or None."""
+    scope_sql, scope_params = _scope_sql(scope)
     return con.execute(
-        _SUMMARY_SELECT + " WHERE canonical_thread_id = ? ORDER BY segment_index LIMIT 1",
-        (canonical_thread_id,),
+        _SUMMARY_SELECT
+        + f" WHERE canonical_thread_id = ? AND {scope_sql} ORDER BY segment_index LIMIT 1",
+        (canonical_thread_id, *scope_params),
     ).fetchone()
 
 
-def get_thread_summaries(con: sqlite3.Connection, canonical_thread_id: str) -> list:
-    """Return all segments for a thread in segment_index order (10-col layout).
+def get_thread_summaries(con: sqlite3.Connection, canonical_thread_id: str, *,
+                         scope: tuple = _DEFAULT_SCOPE) -> list:
+    """Return all in-scope segments for a thread in segment_index order (10-col layout).
 
     Returns an empty list if the thread has no summary yet.
     Use this when you need the full picture of a thread (e.g. for display),
     rather than get_thread_summary which returns only the first segment.
     """
+    scope_sql, scope_params = _scope_sql(scope)
     return con.execute(
-        _SUMMARY_SELECT + " WHERE canonical_thread_id = ? ORDER BY segment_index",
-        (canonical_thread_id,),
+        _SUMMARY_SELECT
+        + f" WHERE canonical_thread_id = ? AND {scope_sql} ORDER BY segment_index",
+        (canonical_thread_id, *scope_params),
     ).fetchall()
 
 
-def get_summary_by_id(con: sqlite3.Connection, summary_id: str):
+def get_summary_by_id(con: sqlite3.Connection, summary_id: str, *,
+                      scope: tuple = _DEFAULT_SCOPE):
     """Fetch a single segment by summary_id using the 10-col layout."""
+    scope_sql, scope_params = _scope_sql(scope)
     return con.execute(
-        _SUMMARY_SELECT + " WHERE summary_id = ?",
-        (summary_id,),
+        _SUMMARY_SELECT + f" WHERE summary_id = ? AND {scope_sql}",
+        (summary_id, *scope_params),
     ).fetchone()
 
 
 def list_thread_summaries(
     con: sqlite3.Connection,
     limit: int = 100,
-    platform: Optional[str] = None,
+    platform: str | list[str] | None = None,
     since_iso: Optional[str] = None,
+    *,
+    scope: tuple = _DEFAULT_SCOPE,
 ):
     """Returns rows in the 10-col layout, one row per segment, ordered newest first.
 
     10-col layout: summary_id[0], canonical_thread_id[1], segment_index[2], title[3],
     platform[4], message_count[5], ts_start[6], ts_end[7], summary[8], key_topics[9].
     """
+    scope_sql, scope_params = _scope_sql(scope)
     sql = _SUMMARY_SELECT
     params: list = []
-    conditions = []
+    conditions = [scope_sql]
+    params.extend(scope_params)
     if platform:
-        conditions.append("platform = ?")
-        params.append(platform)
+        # Accept a list like the other search functions (callers pass parsed
+        # platform lists; a single string still works).
+        platforms = [platform] if isinstance(platform, str) else list(platform)
+        placeholders = ",".join("?" * len(platforms))
+        conditions.append(f"platform IN ({placeholders})")
+        params.extend(platforms)
     if since_iso:
         conditions.append("ts_start >= ?")
         params.append(since_iso)
-    if conditions:
-        sql += " WHERE " + " AND ".join(conditions)
+    sql += " WHERE " + " AND ".join(conditions)
     sql += " ORDER BY ts_start DESC, segment_index ASC LIMIT ?"
     params.append(limit)
     return con.execute(sql, params).fetchall()
 
 
 def search_thread_summaries(
-    con: sqlite3.Connection, embedding: list[float], limit: int = 10
+    con: sqlite3.Connection, embedding: list[float], limit: int = 10, *,
+    scope: tuple = _DEFAULT_SCOPE,
 ):
     """Vector KNN search on thread summaries. Returns [(summary_id, distance)]."""
-    return con.execute(
+    scope = _validate_scope(scope)
+    scope_active = set(scope) != set(SENSITIVITY_LEVELS)
+    fetch_limit = limit * 5 if scope_active else limit
+    raw = con.execute(
         "SELECT summary_id, distance FROM vec_thread_summaries "
         "WHERE embedding MATCH ? AND k = ?",
-        (serialize_f32(embedding), limit),
+        (serialize_f32(embedding), fetch_limit),
     ).fetchall()
+    if not scope_active or not raw:
+        return raw[:limit]
+    ids = [r[0] for r in raw]
+    scope_sql, scope_params = _scope_sql(scope)
+    placeholders = ",".join("?" * len(ids))
+    allowed = {
+        r[0] for r in con.execute(
+            f"SELECT summary_id FROM thread_summaries "
+            f"WHERE summary_id IN ({placeholders}) AND {scope_sql}",
+            (*ids, *scope_params),
+        ).fetchall()
+    }
+    return [(sid, dist) for sid, dist in raw if sid in allowed][:limit]
 
 
 def summary_count(con: sqlite3.Connection) -> int:
@@ -987,9 +1230,18 @@ def delete_group(con: sqlite3.Connection, group_id: str) -> bool:
     return cur.rowcount > 0
 
 
-def get_threads_in_group(con: sqlite3.Connection, group_id: str) -> list[dict]:
-    """Return thread metadata for all members of a group."""
-    rows = con.execute("""
+def get_threads_in_group(con: sqlite3.Connection, group_id: str, *,
+                         scope: tuple = _DEFAULT_SCOPE) -> list[dict]:
+    """Return thread metadata for in-scope members of a group.
+
+    Mixed threads fail closed: any out-of-scope message hides the whole thread
+    (titles and aggregates leak topics).
+    """
+    scope = _validate_scope(scope)
+    max_allowed_rank = max(
+        {"public": 0, "private": 1, "sealed": 2}[s] for s in scope
+    )
+    rows = con.execute(f"""
         SELECT m.canonical_thread_id,
                MAX(msgs.platform) AS platform,
                MAX(msgs.title) AS title,
@@ -1000,8 +1252,9 @@ def get_threads_in_group(con: sqlite3.Connection, group_id: str) -> list[dict]:
         JOIN messages msgs ON msgs.canonical_thread_id = m.canonical_thread_id
         WHERE m.group_id = ?
         GROUP BY m.canonical_thread_id
+        HAVING MAX(CASE msgs.sensitivity WHEN 'sealed' THEN 2 WHEN 'private' THEN 1 ELSE 0 END) <= ?
         ORDER BY ts_start DESC
-    """, (group_id,)).fetchall()
+    """, (group_id, max_allowed_rank)).fetchall()
     return [
         {"canonical_thread_id": r[0], "platform": r[1], "title": r[2],
          "message_count": r[3], "ts_start": r[4], "ts_end": r[5]}
@@ -1023,3 +1276,117 @@ def group_count(con: sqlite3.Connection) -> int:
         return con.execute("SELECT count(*) FROM thread_groups").fetchone()[0]
     except sqlite3.OperationalError:
         return 0
+
+
+# ── Sensitivity classification ────────────────────────────────────────────────
+
+_LEVEL_RANK = {"public": 0, "private": 1, "sealed": 2}
+
+
+def set_thread_sensitivity(con: sqlite3.Connection, thread_ids: list[str],
+                           level: str) -> dict:
+    """Set the sensitivity level for whole threads across all content tables.
+
+    Returns per-table update counts. Commits.
+    """
+    _validate_level(level)
+    counts = {"messages": 0, "chunks": 0, "thread_summaries": 0}
+    batch = 500  # keep IN() placeholder lists well under SQLite's variable cap
+    for start in range(0, len(thread_ids), batch):
+        ids = list(thread_ids[start:start + batch])
+        placeholders = ",".join("?" * len(ids))
+        for table in ("messages", "chunks", "thread_summaries"):
+            cur = con.execute(
+                f"UPDATE {table} SET sensitivity = ? "
+                f"WHERE canonical_thread_id IN ({placeholders})",
+                (level, *ids),
+            )
+            counts[table] += cur.rowcount
+    con.commit()
+    return counts
+
+
+def get_thread_sensitivity(con: sqlite3.Connection, canonical_thread_id: str):
+    """Return (effective_level, message_count) for a thread, or None if unknown.
+
+    The effective level is the max over the thread's messages.
+    """
+    row = con.execute(f"""
+        SELECT MAX({_LEVEL_RANK_SQL}), COUNT(*)
+        FROM messages WHERE canonical_thread_id = ?
+    """, (canonical_thread_id,)).fetchone()
+    if not row or not row[1]:
+        return None
+    rank_to_level = {v: k for k, v in _LEVEL_RANK.items()}
+    return (rank_to_level[row[0]], row[1])
+
+
+def sensitivity_counts(con: sqlite3.Connection) -> dict:
+    """Per-level row counts for messages, threads, thoughts, and summaries."""
+    out: dict = {"messages": {}, "threads": {}, "thoughts": {}, "thread_summaries": {}}
+    for table in ("messages", "thoughts", "thread_summaries"):
+        for level, n in con.execute(
+            f"SELECT sensitivity, COUNT(*) FROM {table} GROUP BY sensitivity"
+        ).fetchall():
+            out[table][level] = n
+    rank_to_level = {v: k for k, v in _LEVEL_RANK.items()}
+    for rank, n in con.execute(f"""
+        SELECT max_rank, COUNT(*) FROM (
+            SELECT MAX({_LEVEL_RANK_SQL}) AS max_rank
+            FROM messages GROUP BY canonical_thread_id
+        ) GROUP BY max_rank
+    """).fetchall():
+        out["threads"][rank_to_level[rank]] = n
+    return out
+
+
+def sealed_exists(con: sqlite3.Connection) -> bool:
+    """True if any row in any content table is sealed (hits the partial indexes)."""
+    for table in _SENSITIVITY_TABLES:
+        try:
+            if con.execute(
+                f"SELECT 1 FROM {table} WHERE sensitivity = 'sealed' LIMIT 1"
+            ).fetchone():
+                return True
+        except sqlite3.OperationalError:
+            return False  # pre-v3 archive: no column → nothing sealed
+    return False
+
+
+def threads_before(con: sqlite3.Connection, cutoff_iso: str) -> list[str]:
+    """Thread ids whose last message predates cutoff_iso (thread-scoped --before)."""
+    return [
+        r[0] for r in con.execute(
+            "SELECT canonical_thread_id FROM messages "
+            "GROUP BY canonical_thread_id HAVING MAX(ts) < ? ORDER BY MAX(ts)",
+            (cutoff_iso,),
+        ).fetchall()
+    ]
+
+
+def reconcile_thread_sensitivity(con: sqlite3.Connection) -> int:
+    """Re-apply thread-level classification to rows added after the fact.
+
+    For every thread containing at least one non-public message, raise all of
+    the thread's messages/chunks/summaries to the thread's max level. Never
+    lowers a level and never touches all-public threads, so it re-applies
+    explicit prior classification without silently reclassifying anything.
+    Returns the number of rows raised. Commits.
+    """
+    raised = 0
+    rank_to_level = {v: k for k, v in _LEVEL_RANK.items()}
+    classified = con.execute(f"""
+        SELECT canonical_thread_id, MAX({_LEVEL_RANK_SQL}) AS max_rank
+        FROM messages GROUP BY canonical_thread_id HAVING max_rank > 0
+    """).fetchall()
+    for thread_id, rank in classified:
+        level = rank_to_level[rank]
+        for table in ("messages", "chunks", "thread_summaries"):
+            cur = con.execute(f"""
+                UPDATE {table} SET sensitivity = ?
+                WHERE canonical_thread_id = ?
+                  AND {_LEVEL_RANK_SQL} < ?
+            """, (level, thread_id, rank))
+            raised += cur.rowcount
+    con.commit()
+    return raised

--- a/src/mychatarchive/backends/storage/sqlite.py
+++ b/src/mychatarchive/backends/storage/sqlite.py
@@ -1241,7 +1241,7 @@ def get_threads_in_group(con: sqlite3.Connection, group_id: str, *,
     max_allowed_rank = max(
         {"public": 0, "private": 1, "sealed": 2}[s] for s in scope
     )
-    rows = con.execute(f"""
+    rows = con.execute("""
         SELECT m.canonical_thread_id,
                MAX(msgs.platform) AS platform,
                MAX(msgs.title) AS title,

--- a/src/mychatarchive/cli.py
+++ b/src/mychatarchive/cli.py
@@ -1104,8 +1104,8 @@ def _cmd_classify(args, db_path: Path):
         return
 
     # Bulk selectors: --query / --before. Preview by default, apply only
-    # with --confirm — this is how six years of backlog get classified
-    # without reading them, so it must never fire by accident.
+    # with --confirm — this is how a large backlog gets classified without
+    # reading it, so it must never fire by accident.
     if args.query:
         # Classification tooling must see everything, or already-classified
         # content could never be re-classified.

--- a/src/mychatarchive/cli.py
+++ b/src/mychatarchive/cli.py
@@ -8,6 +8,7 @@ Commands:
     mychatarchive embed               Generate vector embeddings
     mychatarchive summarize           Generate LLM summaries for all threads
     mychatarchive groups              Manage thread groups (list/create/add/remove)
+    mychatarchive classify            Set sensitivity levels (public/private/sealed)
     mychatarchive serve               Start MCP server
     mychatarchive search <query>      Search from the command line
     mychatarchive info                Show archive stats
@@ -30,6 +31,16 @@ def _add_db_arg(parser):
         default=None,
         help=f"Path to SQLite database (default: {get_db_path()})",
     )
+
+
+def _cli_scope(args) -> tuple:
+    """Resolve --include-private/--include-sealed flags into a sensitivity scope."""
+    if getattr(args, "include_sealed", False):
+        print("WARNING: including SEALED content in output.", file=sys.stderr)
+        return ("public", "private", "sealed")
+    if getattr(args, "include_private", False):
+        return ("public", "private")
+    return ("public",)
 
 
 def main():
@@ -116,6 +127,14 @@ def main():
         "--include-thoughts", action="store_true",
         help="Include captured thoughts in the export",
     )
+    export_p.add_argument(
+        "--include-private", action="store_true",
+        help="Include content classified as private (default: public only)",
+    )
+    export_p.add_argument(
+        "--include-sealed", action="store_true",
+        help="Include SEALED content (implies --include-private; prints a warning)",
+    )
     _add_db_arg(export_p)
 
     # --- embed ---
@@ -171,6 +190,12 @@ def main():
         metavar="N",
         help="Messages per summary segment. Threads with more messages get multiple summaries. Default: 15.",
     )
+    summarize_p.add_argument(
+        "--include-private",
+        action="store_true",
+        help="Also summarize private threads (sends their text to the LLM API). "
+             "Sealed threads are never summarized.",
+    )
     _add_db_arg(summarize_p)
 
     # --- groups ---
@@ -211,6 +236,46 @@ def main():
     groups_show.add_argument("name", help="Group name")
     groups_show.add_argument("--limit", type=int, default=50, help="Max threads to show")
     _add_db_arg(groups_show)
+
+    # --- classify ---
+    classify_p = sub.add_parser(
+        "classify",
+        help="Set sensitivity levels (public/private/sealed) so agents only retrieve what you allow",
+    )
+    classify_sel = classify_p.add_mutually_exclusive_group(required=True)
+    classify_sel.add_argument(
+        "--thread", metavar="THREAD_ID",
+        help="Classify one thread (applies immediately)",
+    )
+    classify_sel.add_argument(
+        "--query", metavar="TEXT",
+        help="Bulk-classify every thread containing a keyword match (preview first; apply with --confirm)",
+    )
+    classify_sel.add_argument(
+        "--before", metavar="YYYY-MM-DD",
+        help="Bulk-classify threads whose last message predates this date (preview first; apply with --confirm)",
+    )
+    classify_sel.add_argument(
+        "--list", action="store_true", dest="list_counts",
+        help="Show row counts per sensitivity level",
+    )
+    classify_p.add_argument(
+        "--level", choices=["public", "private", "sealed"], default=None,
+        help="Sensitivity level to apply (required except with --list)",
+    )
+    classify_p.add_argument(
+        "--dry-run", action="store_true",
+        help="Preview what would change without applying (bulk selectors preview by default)",
+    )
+    classify_p.add_argument(
+        "--confirm", action="store_true",
+        help="Actually apply a bulk classification (--query/--before never apply without this)",
+    )
+    classify_p.add_argument(
+        "--limit", type=int, default=500,
+        help="Max threads to show in a bulk preview (default: 500)",
+    )
+    _add_db_arg(classify_p)
 
     # --- serve ---
     serve_p = sub.add_parser("serve", help="Start MCP server")
@@ -281,6 +346,14 @@ def main():
         metavar="GROUP",
         help="Filter to threads in this group (see 'mychatarchive groups list')",
     )
+    search_p.add_argument(
+        "--include-private", action="store_true",
+        help="Include content classified as private (default: public only)",
+    )
+    search_p.add_argument(
+        "--include-sealed", action="store_true",
+        help="Include SEALED content (implies --include-private; prints a warning)",
+    )
     _add_db_arg(search_p)
 
     # --- info ---
@@ -325,6 +398,8 @@ def main():
         _cmd_summarize(args, db_path)
     elif args.command == "groups":
         _cmd_groups(args, db_path)
+    elif args.command == "classify":
+        _cmd_classify(args, db_path)
     elif args.command == "serve":
         _cmd_serve(args, db_path)
     elif args.command == "search":
@@ -693,8 +768,36 @@ def _cmd_export(args, db_path: Path):
 
     from mychatarchive import db
 
+    scope = _cli_scope(args)
+
     if fmt == "sqlite":
+        # A file copy carries EVERYTHING — every table, including sealed rows
+        # and their vectors. It cannot be filtered, so it is refused when
+        # sealed content exists unless the caller explicitly opts in.
         import shutil
+        con = db.get_connection(db_path)
+        db.ensure_schema(con)
+        has_sealed = db.sealed_exists(con)
+        if has_sealed and not args.include_sealed:
+            con.close()
+            print(
+                "This archive contains SEALED content, and a SQLite copy cannot "
+                "be filtered — the file carries every row. Re-run with "
+                "--include-sealed to copy anyway, or use --format json/csv for "
+                "a filtered export.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if "private" not in scope or has_sealed:
+            print(
+                "Note: a SQLite copy includes ALL content regardless of "
+                "sensitivity flags (private" + (" and sealed" if has_sealed else "")
+                + " rows are in the file).",
+                file=sys.stderr,
+            )
+        # Flush WAL frames into the main file so the copy is complete.
+        con.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        con.close()
         shutil.copy2(str(db_path), str(output_path))
         print(f"Database copied to {output_path}")
         size_mb = output_path.stat().st_size / (1024 * 1024)
@@ -702,10 +805,11 @@ def _cmd_export(args, db_path: Path):
         return
 
     con = db.get_connection(db_path)
-    messages = db.export_messages(con, platform=args.platform)
+    db.ensure_schema(con)
+    messages = db.export_messages(con, platform=args.platform, scope=scope)
     thoughts = []
     if args.include_thoughts:
-        thoughts = db.export_thoughts(con)
+        thoughts = db.export_thoughts(con, scope=scope)
     con.close()
 
     if fmt == "json":
@@ -729,7 +833,8 @@ def _cmd_export(args, db_path: Path):
             writer = csv.DictWriter(
                 f,
                 fieldnames=["message_id", "thread_id", "platform", "account_id",
-                            "timestamp", "role", "content", "title", "source_id"],
+                            "timestamp", "role", "content", "title", "source_id",
+                            "sensitivity"],
             )
             writer.writeheader()
             writer.writerows(messages)
@@ -792,6 +897,7 @@ def _cmd_summarize(args, db_path: Path):
             limit=args.limit,
             embed_summaries=not args.no_embed,
             messages_per_segment=messages_per_segment,
+            include_private=getattr(args, "include_private", False),
         )
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -941,6 +1047,124 @@ def _cmd_groups_list(db_path: Path):
     print("  mychatarchive search 'query' --group <name>  search within a group")
 
 
+def _cmd_classify(args, db_path: Path):
+    if not db_path.exists():
+        print(f"No database found at {db_path}. Import chats first.", file=sys.stderr)
+        sys.exit(1)
+
+    from mychatarchive import db
+
+    con = db.get_connection(db_path)
+    db.ensure_schema(con)  # write path — also the migration trigger
+
+    if args.list_counts:
+        counts = db.sensitivity_counts(con)
+        con.close()
+        print(f"Sensitivity levels - {db_path}")
+        print(f"{'-' * 60}")
+        header = f"  {'':<18}{'public':>10}{'private':>10}{'sealed':>10}"
+        print(header)
+        for label, key in (("Threads", "threads"), ("Messages", "messages"),
+                           ("Thoughts", "thoughts"), ("Summaries", "thread_summaries")):
+            row = counts[key]
+            print(f"  {label:<18}{row.get('public', 0):>10,}"
+                  f"{row.get('private', 0):>10,}{row.get('sealed', 0):>10,}")
+        print()
+        print("Commands:")
+        print("  mychatarchive classify --thread <id> --level private")
+        print("  mychatarchive classify --query 'text' --level sealed --confirm")
+        print("  mychatarchive classify --before 2023-01-01 --level private --confirm")
+        return
+
+    if not args.level:
+        print("--level is required (public, private, or sealed).", file=sys.stderr)
+        con.close()
+        sys.exit(1)
+
+    def _warn_if_sealed():
+        if args.level == "sealed":
+            print(
+                "WARNING: sealed content is never returned by the MCP server and "
+                "is hidden from search/export unless you pass --include-sealed.",
+                file=sys.stderr,
+            )
+
+    if args.thread:
+        current = db.get_thread_sensitivity(con, args.thread)
+        if current is None:
+            print(f"Thread '{args.thread}' not found.", file=sys.stderr)
+            con.close()
+            sys.exit(1)
+        _warn_if_sealed()
+        counts = db.set_thread_sensitivity(con, [args.thread], args.level)
+        con.close()
+        print(f"Thread {args.thread}: {current[0]} -> {args.level}")
+        print(f"  Updated: {counts['messages']} messages, {counts['chunks']} chunks, "
+              f"{counts['thread_summaries']} summary segments")
+        return
+
+    # Bulk selectors: --query / --before. Preview by default, apply only
+    # with --confirm — this is how six years of backlog get classified
+    # without reading them, so it must never fire by accident.
+    if args.query:
+        # Classification tooling must see everything, or already-classified
+        # content could never be re-classified.
+        matches = db.fts_search(con, args.query, limit=10000,
+                                scope=db.SENSITIVITY_LEVELS)
+        thread_ids = sorted({row[2] for row in matches})
+        selector_desc = f"threads with keyword match for {args.query!r}"
+    else:
+        import datetime
+        try:
+            datetime.datetime.strptime(args.before, "%Y-%m-%d")
+        except ValueError:
+            print("Invalid --before format. Use YYYY-MM-DD.", file=sys.stderr)
+            con.close()
+            sys.exit(1)
+        thread_ids = db.threads_before(con, args.before)
+        selector_desc = f"threads whose last message predates {args.before}"
+
+    if not thread_ids:
+        print(f"No {selector_desc}. Nothing to do.")
+        con.close()
+        return
+
+    # Preview: level distribution + a capped listing.
+    print(f"{len(thread_ids):,} {selector_desc}")
+    print(f"{'-' * 60}")
+    shown = 0
+    total_msgs = 0
+    for tid in thread_ids:
+        info = db.get_thread_sensitivity(con, tid)
+        if info is None:
+            continue
+        level, msg_count = info
+        total_msgs += msg_count
+        if shown < args.limit:
+            print(f"  {tid}  [{level}, {msg_count} msgs]")
+            shown += 1
+    if shown < len(thread_ids):
+        print(f"  ... and {len(thread_ids) - shown:,} more (raise --limit to see them)")
+    print()
+    print(f"Would set {len(thread_ids):,} threads / {total_msgs:,} messages "
+          f"(plus their chunks and summaries) to '{args.level}'.")
+
+    if args.dry_run or not args.confirm:
+        con.close()
+        if args.dry_run:
+            print("\nDry run - nothing changed.")
+        else:
+            print("\nPreview only - re-run with --confirm to apply.")
+        return
+
+    _warn_if_sealed()
+    counts = db.set_thread_sensitivity(con, thread_ids, args.level)
+    con.close()
+    print(f"\nApplied '{args.level}' to {len(thread_ids):,} threads: "
+          f"{counts['messages']:,} messages, {counts['chunks']:,} chunks, "
+          f"{counts['thread_summaries']:,} summary segments.")
+
+
 def _cmd_serve(args, db_path: Path):
     if not db_path.exists():
         print(f"No database found at {db_path}. Import and embed chats first.", file=sys.stderr)
@@ -971,6 +1195,8 @@ def _cmd_search(args, db_path: Path):
     import datetime
 
     con = db.get_connection(db_path)
+    db.ensure_schema(con)
+    scope = _cli_scope(args)
     platform = args.platform if args.platform else None
     sort_by_time = args.sort == "time"
 
@@ -1009,7 +1235,7 @@ def _cmd_search(args, db_path: Path):
         results = db.search_chunks(
             con, embedding, limit=args.limit, platform=platform,
             cutoff_iso=cutoff_iso, sort_by_time=sort_by_time,
-            group_thread_ids=group_thread_ids,
+            group_thread_ids=group_thread_ids, scope=scope,
         )
 
         if not results:
@@ -1018,7 +1244,7 @@ def _cmd_search(args, db_path: Path):
             return
 
         for i, (chunk_id, distance) in enumerate(results, 1):
-            row = db.get_chunk_by_id(con, chunk_id)
+            row = db.get_chunk_by_id(con, chunk_id, scope=scope)
             if row:
                 meta = json.loads(row[4]) if row[4] else {}
                 similarity = round(1.0 - distance, 4)
@@ -1032,7 +1258,7 @@ def _cmd_search(args, db_path: Path):
         results = db.fts_search(
             con, query, limit=args.limit, platform=platform,
             cutoff_iso=cutoff_iso, sort_by_time=sort_by_time,
-            group_thread_ids=group_thread_ids,
+            group_thread_ids=group_thread_ids, scope=scope,
         )
         if not results:
             print("No results found.")
@@ -1071,6 +1297,12 @@ def _cmd_info(db_path: Path):
         platforms = db.platform_counts(con)
     except Exception:
         platforms = []
+    # Guarded like platform_counts: the plain-sqlite3 fallback connection may
+    # be a pre-v3 archive with no sensitivity column.
+    try:
+        sens_threads = db.sensitivity_counts(con).get("threads", {})
+    except Exception:
+        sens_threads = {}
     con.close()
 
     print(f"MyChatArchive - {db_path}")
@@ -1081,6 +1313,9 @@ def _cmd_info(db_path: Path):
     print(f"  Embedded:    {chunks:,} chunks")
     print(f"  Thoughts:    {thoughts:,}")
     print(f"  Groups:      {groups:,}")
+    if sens_threads:
+        parts = [f"{level}: {n:,}" for level, n in sorted(sens_threads.items())]
+        print(f"  Sensitivity: {' | '.join(parts)} (threads)")
     if platforms:
         print(f"  Platforms:")
         for plat, count in platforms:

--- a/src/mychatarchive/db.py
+++ b/src/mychatarchive/db.py
@@ -11,6 +11,14 @@ from typing import Optional
 
 from mychatarchive.backends import get_storage
 
+# Sensitivity levels, least to most restricted. Duplicated here (not imported
+# from a backend) so callers can reference them without eagerly importing a
+# storage backend — backends load lazily by design.
+SENSITIVITY_LEVELS = ("public", "private", "sealed")
+
+# Fail-closed default: callers that don't name a scope see public rows only.
+DEFAULT_SCOPE = ("public",)
+
 
 def _b():
     return get_storage()
@@ -57,8 +65,8 @@ def platform_counts(con) -> list[tuple[str, int]]:
     return _b().platform_counts(con)
 
 
-def iter_messages(con, batch_size: int = 1000):
-    return _b().iter_messages(con, batch_size)
+def iter_messages(con, batch_size: int = 1000, *, scope: tuple = DEFAULT_SCOPE):
+    return _b().iter_messages(con, batch_size, scope=scope)
 
 
 def embedded_message_ids(con) -> set[str]:
@@ -73,16 +81,18 @@ def clear_chunks(con) -> None:
 def insert_chunk(con, chunk_id: str, message_id: Optional[str],
                  thread_id: str, chunk_index: int, text: str,
                  ts_start: str, ts_end: str, embedding: list[float],
-                 meta: Optional[dict] = None):
+                 meta: Optional[dict] = None, *, sensitivity: str = "public"):
     return _b().insert_chunk(
         con, chunk_id, message_id, thread_id, chunk_index,
-        text, ts_start, ts_end, embedding, meta,
+        text, ts_start, ts_end, embedding, meta, sensitivity=sensitivity,
     )
 
 
 def insert_thought(con, thought_id: str, text: str, created_at: str,
-                   embedding: list[float], meta: Optional[dict] = None):
-    return _b().insert_thought(con, thought_id, text, created_at, embedding, meta)
+                   embedding: list[float], meta: Optional[dict] = None,
+                   *, sensitivity: str = "public"):
+    return _b().insert_thought(con, thought_id, text, created_at, embedding, meta,
+                               sensitivity=sensitivity)
 
 
 def search_chunks(
@@ -93,16 +103,19 @@ def search_chunks(
     cutoff_iso: str | None = None,
     sort_by_time: bool = False,
     group_thread_ids: set | None = None,
+    *,
+    scope: tuple = DEFAULT_SCOPE,
 ):
     return _b().search_chunks(
         con, embedding, limit=limit, platform=platform,
         cutoff_iso=cutoff_iso, sort_by_time=sort_by_time,
-        group_thread_ids=group_thread_ids,
+        group_thread_ids=group_thread_ids, scope=scope,
     )
 
 
-def search_thoughts(con, embedding: list[float], limit: int = 10):
-    return _b().search_thoughts(con, embedding, limit)
+def search_thoughts(con, embedding: list[float], limit: int = 10, *,
+                    scope: tuple = DEFAULT_SCOPE):
+    return _b().search_thoughts(con, embedding, limit, scope=scope)
 
 
 def fts_search(
@@ -113,11 +126,13 @@ def fts_search(
     cutoff_iso: str | None = None,
     sort_by_time: bool = False,
     group_thread_ids: set | None = None,
+    *,
+    scope: tuple = DEFAULT_SCOPE,
 ):
     return _b().fts_search(
         con, query, limit=limit, platform=platform,
         cutoff_iso=cutoff_iso, sort_by_time=sort_by_time,
-        group_thread_ids=group_thread_ids,
+        group_thread_ids=group_thread_ids, scope=scope,
     )
 
 
@@ -126,38 +141,43 @@ def get_recent_chunks(
     cutoff_iso: str,
     limit: int = 20,
     platform: str | list[str] | None = None,
+    *,
+    scope: tuple = DEFAULT_SCOPE,
 ):
-    return _b().get_recent_chunks(con, cutoff_iso, limit=limit, platform=platform)
+    return _b().get_recent_chunks(con, cutoff_iso, limit=limit, platform=platform, scope=scope)
 
 
-def get_recent_thoughts(con, cutoff_iso: str, limit: int = 20):
-    return _b().get_recent_thoughts(con, cutoff_iso, limit)
+def get_recent_thoughts(con, cutoff_iso: str, limit: int = 20, *,
+                        scope: tuple = DEFAULT_SCOPE):
+    return _b().get_recent_thoughts(con, cutoff_iso, limit, scope=scope)
 
 
-def get_chunk_by_id(con, chunk_id: str):
-    return _b().get_chunk_by_id(con, chunk_id)
+def get_chunk_by_id(con, chunk_id: str, *, scope: tuple = DEFAULT_SCOPE):
+    return _b().get_chunk_by_id(con, chunk_id, scope=scope)
 
 
-def get_thought_by_id(con, thought_id: str):
-    return _b().get_thought_by_id(con, thought_id)
+def get_thought_by_id(con, thought_id: str, *, scope: tuple = DEFAULT_SCOPE):
+    return _b().get_thought_by_id(con, thought_id, scope=scope)
 
 
-def export_messages(con, platform: str | None = None, limit: int | None = None):
-    return _b().export_messages(con, platform=platform, limit=limit)
+def export_messages(con, platform: str | None = None, limit: int | None = None,
+                    *, scope: tuple = DEFAULT_SCOPE):
+    return _b().export_messages(con, platform=platform, limit=limit, scope=scope)
 
 
-def export_thoughts(con):
-    return _b().export_thoughts(con)
+def export_thoughts(con, *, scope: tuple = DEFAULT_SCOPE):
+    return _b().export_thoughts(con, scope=scope)
 
 
 # ── Thread summaries ──────────────────────────────────────────────────────────
 
-def iter_threads(con):
-    return _b().iter_threads(con)
+def iter_threads(con, *, scope: tuple = DEFAULT_SCOPE):
+    return _b().iter_threads(con, scope=scope)
 
 
-def get_thread_messages(con, canonical_thread_id: str) -> list[dict]:
-    return _b().get_thread_messages(con, canonical_thread_id)
+def get_thread_messages(con, canonical_thread_id: str, *,
+                        scope: tuple = DEFAULT_SCOPE) -> list[dict]:
+    return _b().get_thread_messages(con, canonical_thread_id, scope=scope)
 
 
 def has_thread_summary(con, canonical_thread_id: str) -> bool:
@@ -179,10 +199,13 @@ def insert_thread_summary(
     key_topics: list,
     summary_model: str,
     now: str,
+    *,
+    sensitivity: str = "public",
 ):
     return _b().insert_thread_summary(
         con, summary_id, canonical_thread_id, segment_index, title, platform,
         message_count, segment_chars, ts_start, ts_end, summary, key_topics, summary_model, now,
+        sensitivity=sensitivity,
     )
 
 
@@ -195,34 +218,38 @@ def delete_thread_summaries(con, canonical_thread_id: str) -> int:
     return _b().delete_thread_summaries(con, canonical_thread_id)
 
 
-def get_thread_summary(con, canonical_thread_id: str):
+def get_thread_summary(con, canonical_thread_id: str, *, scope: tuple = DEFAULT_SCOPE):
     """Returns the first segment (segment_index=0) for a thread using the 10-col layout, or None."""
-    return _b().get_thread_summary(con, canonical_thread_id)
+    return _b().get_thread_summary(con, canonical_thread_id, scope=scope)
 
 
-def get_thread_summaries(con, canonical_thread_id: str) -> list:
+def get_thread_summaries(con, canonical_thread_id: str, *,
+                         scope: tuple = DEFAULT_SCOPE) -> list:
     """Return all segments for a thread in segment_index order (10-col layout).
 
     10-col: summary_id[0], canonical_thread_id[1], segment_index[2], title[3],
     platform[4], message_count[5], ts_start[6], ts_end[7], summary[8], key_topics[9].
     """
-    return _b().get_thread_summaries(con, canonical_thread_id)
+    return _b().get_thread_summaries(con, canonical_thread_id, scope=scope)
 
 
-def get_summary_by_id(con, summary_id: str):
+def get_summary_by_id(con, summary_id: str, *, scope: tuple = DEFAULT_SCOPE):
     """Fetch a single segment by summary_id using the 10-col layout."""
-    return _b().get_summary_by_id(con, summary_id)
+    return _b().get_summary_by_id(con, summary_id, scope=scope)
 
 
-def list_thread_summaries(con, limit: int = 100, platform=None, since_iso=None):
+def list_thread_summaries(con, limit: int = 100, platform=None, since_iso=None,
+                          *, scope: tuple = DEFAULT_SCOPE):
     """10-col layout: summary_id[0], canonical_thread_id[1], segment_index[2], title[3],
     platform[4], message_count[5], ts_start[6], ts_end[7], summary[8], key_topics[9]."""
-    return _b().list_thread_summaries(con, limit=limit, platform=platform, since_iso=since_iso)
+    return _b().list_thread_summaries(con, limit=limit, platform=platform,
+                                      since_iso=since_iso, scope=scope)
 
 
-def search_thread_summaries(con, embedding: list[float], limit: int = 10):
+def search_thread_summaries(con, embedding: list[float], limit: int = 10, *,
+                            scope: tuple = DEFAULT_SCOPE):
     """Returns [(summary_id, distance)]."""
-    return _b().search_thread_summaries(con, embedding, limit)
+    return _b().search_thread_summaries(con, embedding, limit, scope=scope)
 
 
 def summary_count(con) -> int:
@@ -265,8 +292,9 @@ def delete_group(con, group_id: str) -> bool:
     return _b().delete_group(con, group_id)
 
 
-def get_threads_in_group(con, group_id: str) -> list[dict]:
-    return _b().get_threads_in_group(con, group_id)
+def get_threads_in_group(con, group_id: str, *,
+                         scope: tuple = DEFAULT_SCOPE) -> list[dict]:
+    return _b().get_threads_in_group(con, group_id, scope=scope)
 
 
 def get_group_thread_ids(con, group_id: str) -> set:
@@ -275,3 +303,34 @@ def get_group_thread_ids(con, group_id: str) -> set:
 
 def group_count(con) -> int:
     return _b().group_count(con)
+
+
+# ── Sensitivity classification ────────────────────────────────────────────────
+
+def set_thread_sensitivity(con, thread_ids: list, level: str) -> dict:
+    """Set the level for whole threads across messages/chunks/summaries."""
+    return _b().set_thread_sensitivity(con, thread_ids, level)
+
+
+def get_thread_sensitivity(con, canonical_thread_id: str):
+    """Return (effective_level, message_count) for a thread, or None."""
+    return _b().get_thread_sensitivity(con, canonical_thread_id)
+
+
+def sensitivity_counts(con) -> dict:
+    """Per-level counts for messages, threads, thoughts, and summaries."""
+    return _b().sensitivity_counts(con)
+
+
+def sealed_exists(con) -> bool:
+    return _b().sealed_exists(con)
+
+
+def threads_before(con, cutoff_iso: str) -> list:
+    """Thread ids whose last message predates cutoff_iso."""
+    return _b().threads_before(con, cutoff_iso)
+
+
+def reconcile_thread_sensitivity(con) -> int:
+    """Raise newly ingested rows to their thread's already-classified level."""
+    return _b().reconcile_thread_sensitivity(con)

--- a/src/mychatarchive/embeddings.py
+++ b/src/mychatarchive/embeddings.py
@@ -75,7 +75,9 @@ def run(db_path: Path, batch_size: int = 64, force: bool = False):
     skipped = 0
 
     pbar = tqdm(total=total, desc="Embedding", file=sys.stderr)
-    for msg in db.iter_messages(con):
+    # Embedding is local-only, so all sensitivity levels are processed —
+    # private/sealed content stays semantically searchable for opted-in callers.
+    for msg in db.iter_messages(con, scope=db.SENSITIVITY_LEVELS):
         pbar.update(1)
 
         if msg["message_id"] in already_embedded:
@@ -128,6 +130,7 @@ def _flush_batch(con, batch: list[tuple[str, dict, int]]) -> int:
             ts_end=meta["ts"],
             embedding=emb,
             meta={"role": meta["role"], "title": meta["title"]},
+            sensitivity=meta.get("sensitivity", "public"),
         )
 
     con.commit()

--- a/src/mychatarchive/ingest.py
+++ b/src/mychatarchive/ingest.py
@@ -174,6 +174,16 @@ def run(
         con.close()
         return 0, 0
 
+    # New rows land as 'public' by default; if their thread was already
+    # classified private/sealed, raise them to the thread's level before
+    # anything can read them (re-syncing a classified thread must not
+    # reintroduce public rows).
+    if inserted:
+        raised = db.reconcile_thread_sensitivity(con)
+        if raised:
+            print(f"  Sensitivity: {raised} new row(s) inherited their "
+                  f"thread's classification", file=sys.stderr)
+
     total = db.message_count(con)
     con.close()
 

--- a/src/mychatarchive/mcp/server.py
+++ b/src/mychatarchive/mcp/server.py
@@ -27,6 +27,34 @@ mcp = FastMCP("mychatarchive")
 _con = None
 
 
+def _ensure_migrated(con) -> None:
+    """Migrate the archive on open (pre-v3 archives gain the sensitivity column).
+
+    Read paths never ran ensure_schema before v0.4.0; scope-filtered SQL needs
+    the column, so serve must migrate too. If the file is not writable (e.g. a
+    read-only mount), proceed only when the archive is already current.
+    """
+    try:
+        db.ensure_schema(con)
+    except Exception as exc:
+        try:
+            row = con.execute(
+                "SELECT value FROM archive_meta WHERE key = 'schema_version'"
+            ).fetchone()
+            version = int(row[0]) if row else 0
+        except Exception:
+            version = 0
+        if version >= 3:
+            print(f"Warning: schema maintenance failed ({exc}); archive is "
+                  f"already v{version}, continuing read-only.", file=sys.stderr)
+            return
+        raise RuntimeError(
+            f"This archive needs the v3 sensitivity migration but it could not "
+            f"be applied here ({exc}). Run 'mychatarchive classify --list "
+            f"--db <path>' on the host with write access, then restart."
+        ) from exc
+
+
 def _get_con():
     global _con
     if _con is None:
@@ -38,7 +66,19 @@ def _get_con():
             )
             raise FileNotFoundError(f"No database at {db_path}")
         _con = db.get_connection(db_path)
+        _ensure_migrated(_con)
     return _con
+
+
+# The MCP surface can express at most public+private. Sealed does not appear
+# here at all — no parameter value reaches a scope containing it, and this
+# allowlist strips it defensively even if a future edit widens the input.
+_MCP_ALLOWED_LEVELS = ("public", "private")
+
+
+def _scope(include_private: bool) -> tuple:
+    scope = ("public", "private") if include_private else ("public",)
+    return tuple(s for s in scope if s in _MCP_ALLOWED_LEVELS)
 
 
 def _lazy_embed(text: str) -> list[float]:
@@ -86,6 +126,7 @@ def search_brain(
     since: str | None = None,
     sort_by_time: bool = False,
     group: str | None = None,
+    include_private: bool = False,
 ) -> str:
     """Semantic search across all chat history by meaning.
 
@@ -101,8 +142,12 @@ def search_brain(
         since: Only include messages from this date (YYYY-MM-DD)
         sort_by_time: If true, sort by newest first instead of relevance
         group: Filter to threads in this user-curated group (e.g. "jarvis", "coding")
+        include_private: Also search content the user has classified as private.
+            Default false — only set this when the user explicitly asks for
+            private material.
     """
     con = _get_con()
+    scope = _scope(include_private)
     embedding = _lazy_embed(query)
     platforms = [p.strip() for p in platform.split(",")] if platform else None
     group_thread_ids = _resolve_group_thread_ids(con, group)
@@ -123,7 +168,7 @@ def search_brain(
     results = db.search_chunks(
         con, embedding, limit=limit, platform=platforms,
         cutoff_iso=cutoff_iso, sort_by_time=sort_by_time,
-        group_thread_ids=group_thread_ids,
+        group_thread_ids=group_thread_ids, scope=scope,
     )
 
     if not results:
@@ -132,7 +177,7 @@ def search_brain(
 
     output = []
     for chunk_id, distance in results:
-        row = db.get_chunk_by_id(con, chunk_id)
+        row = db.get_chunk_by_id(con, chunk_id, scope=scope)
         if row:
             meta = json.loads(row[4]) if row[4] else {}
             output.append({
@@ -153,6 +198,7 @@ def search_recent(
     hours: int = 24,
     limit: int = 20,
     platform: str | None = None,
+    include_private: bool = False,
 ) -> str:
     """Retrieve recent conversations and captured thoughts by time range.
 
@@ -161,15 +207,18 @@ def search_recent(
         limit: Maximum results per category (default 20)
         platform: Filter by platform (chatgpt, anthropic, grok, claude_code, cursor).
             Comma-separated for multiple. Omit for all.
+        include_private: Also include content the user has classified as private.
+            Default false — only set this when the user explicitly asks.
     """
     con = _get_con()
+    scope = _scope(include_private)
     cutoff = (
         datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=hours)
     ).isoformat()
     platforms = [p.strip() for p in platform.split(",")] if platform else None
 
-    chunk_rows = db.get_recent_chunks(con, cutoff, limit, platform=platforms)
-    thought_rows = db.get_recent_thoughts(con, cutoff, limit)
+    chunk_rows = db.get_recent_chunks(con, cutoff, limit, platform=platforms, scope=scope)
+    thought_rows = db.get_recent_thoughts(con, cutoff, limit, scope=scope)
 
     messages = []
     for row in chunk_rows:
@@ -204,6 +253,7 @@ def get_context(
     since: str | None = None,
     sort_by_time: bool = False,
     group: str | None = None,
+    include_private: bool = False,
 ) -> str:
     """Given a topic, return a comprehensive context bundle.
 
@@ -219,8 +269,11 @@ def get_context(
         since: Only include messages from this date (YYYY-MM-DD)
         sort_by_time: If true, sort by newest first instead of relevance
         group: Filter to threads in this user-curated group (e.g. "jarvis", "coding")
+        include_private: Also include content the user has classified as private.
+            Default false — only set this when the user explicitly asks.
     """
     con = _get_con()
+    scope = _scope(include_private)
     embedding = _lazy_embed(topic)
     platforms = [p.strip() for p in platform.split(",")] if platform else None
     group_thread_ids = _resolve_group_thread_ids(con, group)
@@ -242,14 +295,14 @@ def get_context(
     chunk_results = db.search_chunks(
         con, embedding, limit=limit, platform=platforms,
         cutoff_iso=cutoff_iso, sort_by_time=sort_by_time,
-        group_thread_ids=group_thread_ids,
+        group_thread_ids=group_thread_ids, scope=scope,
     )
-    thought_results = db.search_thoughts(con, embedding, limit=5)
+    thought_results = db.search_thoughts(con, embedding, limit=5, scope=scope)
 
     related_messages = []
     thread_ids = set()
     for chunk_id, distance in chunk_results:
-        row = db.get_chunk_by_id(con, chunk_id)
+        row = db.get_chunk_by_id(con, chunk_id, scope=scope)
         if row:
             meta = json.loads(row[4]) if row[4] else {}
             related_messages.append({
@@ -268,7 +321,7 @@ def get_context(
     #         platform[4], message_count[5], ts_start[6], ts_end[7], summary[8], key_topics[9]
     thread_summaries_out = []
     for tid in list(thread_ids)[:5]:
-        segs = db.get_thread_summaries(con, tid)
+        segs = db.get_thread_summaries(con, tid, scope=scope)
         if not segs:
             continue
         # Merge all segments into a single thread-level summary
@@ -304,7 +357,7 @@ def get_context(
 
     related_thoughts = []
     for thought_id, distance in thought_results:
-        row = db.get_thought_by_id(con, thought_id)
+        row = db.get_thought_by_id(con, thought_id, scope=scope)
         if row:
             related_thoughts.append({
                 "text": row[0],
@@ -324,7 +377,7 @@ def get_context(
 
 
 @mcp.tool()
-def capture_thought(thought: str, tags: str = "") -> str:
+def capture_thought(thought: str, tags: str = "", sensitivity: str = "public") -> str:
     """Capture a new thought or note into your archive with auto-embedding.
 
     The thought is stored and embedded so it's retrievable via search_brain later.
@@ -333,7 +386,20 @@ def capture_thought(thought: str, tags: str = "") -> str:
     Args:
         thought: The thought or note to capture
         tags: Optional comma-separated tags for organization
+        sensitivity: "public" (default) or "private". Private thoughts are only
+            returned when a retrieval call sets include_private. ("sealed" is
+            managed from the CLI, never over MCP.)
     """
+    if sensitivity not in _MCP_ALLOWED_LEVELS:
+        # Sealing over MCP is rejected by design: an agent sealing content it
+        # just wrote would make it invisible to its own session, and sealed
+        # stays CLI-only end to end.
+        return json.dumps({
+            "error": f"sensitivity must be one of {list(_MCP_ALLOWED_LEVELS)}; "
+                     f"sealed content is managed via the mychatarchive CLI.",
+            **_current_datetime_json(),
+        })
+
     con = _get_con()
     now = datetime.datetime.now(datetime.timezone.utc).isoformat()
     thought_id = hashlib.sha1(f"{now}|{thought[:64]}".encode()).hexdigest()
@@ -341,7 +407,8 @@ def capture_thought(thought: str, tags: str = "") -> str:
     embedding = _lazy_embed(thought)
     meta = {"tags": [t.strip() for t in tags.split(",") if t.strip()]} if tags else None
 
-    db.insert_thought(con, thought_id, thought, now, embedding, meta)
+    db.insert_thought(con, thought_id, thought, now, embedding, meta,
+                      sensitivity=sensitivity)
     con.commit()
 
     out = {
@@ -359,6 +426,7 @@ def get_profile(
     days_back: int = 30,
     platform: str | None = None,
     group: str | None = None,
+    include_private: bool = False,
 ) -> str:
     """Get a snapshot of the user's current context: active projects, themes, recent focus.
 
@@ -370,8 +438,11 @@ def get_profile(
         days_back: How many days of history to include (default 30)
         platform: Filter by platform (chatgpt, anthropic, grok, claude_code, cursor)
         group: Filter to threads in a specific group (e.g. "jarvis", "coding")
+        include_private: Also include content the user has classified as private.
+            Default false — only set this when the user explicitly asks.
     """
     con = _get_con()
+    scope = _scope(include_private)
     cutoff = (
         datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=days_back)
     ).isoformat()
@@ -382,7 +453,7 @@ def get_profile(
     # 10-col layout: summary_id[0], canonical_thread_id[1], segment_index[2], title[3],
     #                platform[4], message_count[5], ts_start[6], ts_end[7], summary[8], key_topics[9]
     recent_summaries_raw = db.list_thread_summaries(
-        con, limit=20, platform=platform, since_iso=cutoff
+        con, limit=20, platform=platforms, since_iso=cutoff, scope=scope
     )
     thread_summaries = []
     for row in recent_summaries_raw:
@@ -400,7 +471,7 @@ def get_profile(
         })
 
     # 2. Recent message chunks (always include — fallback if no summaries)
-    chunk_rows = db.get_recent_chunks(con, cutoff, limit=15, platform=platforms)
+    chunk_rows = db.get_recent_chunks(con, cutoff, limit=15, platform=platforms, scope=scope)
     recent_messages = []
     seen_threads: set[str] = set()
     for row in chunk_rows:
@@ -418,7 +489,7 @@ def get_profile(
         })
 
     # 3. Recent captured thoughts
-    thought_rows = db.get_recent_thoughts(con, cutoff, limit=10)
+    thought_rows = db.get_recent_thoughts(con, cutoff, limit=10, scope=scope)
     thoughts = [{"text": r[1], "created_at": r[2]} for r in thought_rows]
 
     # 4. Aggregate key topics from summaries for a "focus areas" view
@@ -457,6 +528,7 @@ def run(db_path: Path | None = None, transport: str = "stdio", port: int = 8420,
     if db_path:
         global _con
         _con = db.get_connection(db_path)
+        _ensure_migrated(_con)
 
     if transport == "sse":
         print(f"Starting MCP server with SSE transport on port {port}", file=sys.stderr)

--- a/src/mychatarchive/summarizer.py
+++ b/src/mychatarchive/summarizer.py
@@ -172,11 +172,16 @@ def run(
     limit: int | None = None,
     embed_summaries: bool = True,
     messages_per_segment: int = _DEFAULT_MESSAGES_PER_SEGMENT,
+    include_private: bool = False,
 ) -> dict:
     """Generate LLM summaries for all unsummarized threads.
 
     Long threads are split into segments of messages_per_segment messages each.
     Each segment gets its own summary row and embedding in the DB.
+
+    Summarization sends raw thread text to an external LLM API — the one place
+    archive content leaves the machine. Sealed threads are never summarized;
+    private threads only with include_private=True.
 
     Args:
         db_path:              Path to archive.db
@@ -187,6 +192,8 @@ def run(
         limit:                Max threads to process in this run
         embed_summaries:      Also embed summaries for thread-level semantic search
         messages_per_segment: Messages per summary segment (default: 15)
+        include_private:      Also summarize private threads (sealed never leaves
+                              the machine regardless)
 
     Returns:
         {"processed": N, "skipped": N, "errors": N, "total_threads": N, "segments": N}
@@ -210,10 +217,12 @@ def run(
 
     now_str = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
-    # Collect threads to process
-    threads = list(db.iter_threads(con))
+    # Collect threads to process. Scope is explicit egress control: this is
+    # the only path that ships raw archive text to an external API.
+    scope = ("public", "private") if include_private else ("public",)
+    threads = list(db.iter_threads(con, scope=scope))
     total = len(threads)
-    print(f"  [summarize] {total:,} threads in archive", file=sys.stderr)
+    print(f"  [summarize] {total:,} threads in scope {list(scope)}", file=sys.stderr)
 
     if not force:
         threads = [t for t in threads if not db.has_thread_summary(con, t["canonical_thread_id"])]
@@ -251,7 +260,7 @@ def run(
     for thread_meta in iterator:
         thread_id = thread_meta["canonical_thread_id"]
         try:
-            messages = db.get_thread_messages(con, thread_id)
+            messages = db.get_thread_messages(con, thread_id, scope=scope)
             if not messages:
                 continue
 
@@ -288,6 +297,7 @@ def run(
                     key_topics=key_topics,
                     summary_model=model,
                     now=now_str,
+                    sensitivity=thread_meta.get("sensitivity", "public"),
                 )
 
                 if embedder:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,9 +42,9 @@ def _seeded_db(tmp_path):
     db_file = tmp_path / "archive.db"
     con = store.get_connection(db_file)
     store.ensure_schema(con)
-    store.insert_message(con, "m1", "t-med", "chatgpt", "main",
+    store.insert_message(con, "m1", "t-px", "chatgpt", "main",
                          "2024-01-01T00:00:00", "user",
-                         "my medical appointment", "Medical", "s")
+                         "planning the project-x rollout", "Project X", "s")
     store.insert_message(con, "m2", "t-code", "chatgpt", "main",
                          "2024-06-01T00:00:00", "user",
                          "rust borrow checker", "Code", "s")
@@ -56,7 +56,7 @@ def _seeded_db(tmp_path):
 def test_classify_query_never_applies_without_confirm(tmp_path, monkeypatch, capsys):
     db_file = _seeded_db(tmp_path)
 
-    _run(["classify", "--query", "medical", "--level", "sealed",
+    _run(["classify", "--query", "project-x", "--level", "sealed",
           "--db", str(db_file)], monkeypatch)
     out = capsys.readouterr().out
     assert "Preview only" in out
@@ -74,7 +74,7 @@ def test_classify_query_never_applies_without_confirm(tmp_path, monkeypatch, cap
 def test_classify_query_applies_with_confirm(tmp_path, monkeypatch, capsys):
     db_file = _seeded_db(tmp_path)
 
-    _run(["classify", "--query", "medical", "--level", "sealed", "--confirm",
+    _run(["classify", "--query", "project-x", "--level", "sealed", "--confirm",
           "--db", str(db_file)], monkeypatch)
     assert "Applied 'sealed' to 1 threads" in capsys.readouterr().out
 
@@ -83,13 +83,13 @@ def test_classify_query_applies_with_confirm(tmp_path, monkeypatch, capsys):
         "SELECT canonical_thread_id, sensitivity FROM messages"
     ).fetchall())
     con.close()
-    assert rows == {"t-med": "sealed", "t-code": "public"}
+    assert rows == {"t-px": "sealed", "t-code": "public"}
 
 
 def test_classify_dry_run_wins_over_confirm(tmp_path, monkeypatch, capsys):
     db_file = _seeded_db(tmp_path)
 
-    _run(["classify", "--query", "medical", "--level", "sealed",
+    _run(["classify", "--query", "project-x", "--level", "sealed",
           "--confirm", "--dry-run", "--db", str(db_file)], monkeypatch)
     assert "Dry run" in capsys.readouterr().out
     con = sqlite3.connect(db_file)
@@ -110,12 +110,12 @@ def test_classify_before_is_thread_scoped_on_last_message(tmp_path, monkeypatch,
         "SELECT canonical_thread_id, sensitivity FROM messages"
     ).fetchall())
     con.close()
-    assert rows == {"t-med": "private", "t-code": "public"}
+    assert rows == {"t-px": "private", "t-code": "public"}
 
 
 def test_sqlite_export_refuses_sealed_without_flag(tmp_path, monkeypatch, capsys):
     db_file = _seeded_db(tmp_path)
-    _run(["classify", "--thread", "t-med", "--level", "sealed",
+    _run(["classify", "--thread", "t-px", "--level", "sealed",
           "--db", str(db_file)], monkeypatch)
     capsys.readouterr()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,3 +33,100 @@ def test_groups_subcommands_accept_db_flag(tmp_path, monkeypatch, capsys):
 
     _run(["groups", "list", "--db", str(db_file)], monkeypatch)
     assert "jarvis" in capsys.readouterr().out
+
+
+def _seeded_db(tmp_path):
+    """Archive with two threads for classify tests."""
+    from mychatarchive.backends.storage import sqlite as store
+
+    db_file = tmp_path / "archive.db"
+    con = store.get_connection(db_file)
+    store.ensure_schema(con)
+    store.insert_message(con, "m1", "t-med", "chatgpt", "main",
+                         "2024-01-01T00:00:00", "user",
+                         "my medical appointment", "Medical", "s")
+    store.insert_message(con, "m2", "t-code", "chatgpt", "main",
+                         "2024-06-01T00:00:00", "user",
+                         "rust borrow checker", "Code", "s")
+    con.commit()
+    con.close()
+    return db_file
+
+
+def test_classify_query_never_applies_without_confirm(tmp_path, monkeypatch, capsys):
+    db_file = _seeded_db(tmp_path)
+
+    _run(["classify", "--query", "medical", "--level", "sealed",
+          "--db", str(db_file)], monkeypatch)
+    out = capsys.readouterr().out
+    assert "Preview only" in out
+
+    _run(["classify", "--list", "--db", str(db_file)], monkeypatch)
+    assert "sealed" in capsys.readouterr().out  # header row only
+    con = sqlite3.connect(db_file)
+    sealed = con.execute(
+        "SELECT count(*) FROM messages WHERE sensitivity='sealed'"
+    ).fetchone()[0]
+    con.close()
+    assert sealed == 0
+
+
+def test_classify_query_applies_with_confirm(tmp_path, monkeypatch, capsys):
+    db_file = _seeded_db(tmp_path)
+
+    _run(["classify", "--query", "medical", "--level", "sealed", "--confirm",
+          "--db", str(db_file)], monkeypatch)
+    assert "Applied 'sealed' to 1 threads" in capsys.readouterr().out
+
+    con = sqlite3.connect(db_file)
+    rows = dict(con.execute(
+        "SELECT canonical_thread_id, sensitivity FROM messages"
+    ).fetchall())
+    con.close()
+    assert rows == {"t-med": "sealed", "t-code": "public"}
+
+
+def test_classify_dry_run_wins_over_confirm(tmp_path, monkeypatch, capsys):
+    db_file = _seeded_db(tmp_path)
+
+    _run(["classify", "--query", "medical", "--level", "sealed",
+          "--confirm", "--dry-run", "--db", str(db_file)], monkeypatch)
+    assert "Dry run" in capsys.readouterr().out
+    con = sqlite3.connect(db_file)
+    sealed = con.execute(
+        "SELECT count(*) FROM messages WHERE sensitivity='sealed'"
+    ).fetchone()[0]
+    con.close()
+    assert sealed == 0
+
+
+def test_classify_before_is_thread_scoped_on_last_message(tmp_path, monkeypatch, capsys):
+    db_file = _seeded_db(tmp_path)
+
+    _run(["classify", "--before", "2024-03-01", "--level", "private", "--confirm",
+          "--db", str(db_file)], monkeypatch)
+    con = sqlite3.connect(db_file)
+    rows = dict(con.execute(
+        "SELECT canonical_thread_id, sensitivity FROM messages"
+    ).fetchall())
+    con.close()
+    assert rows == {"t-med": "private", "t-code": "public"}
+
+
+def test_sqlite_export_refuses_sealed_without_flag(tmp_path, monkeypatch, capsys):
+    db_file = _seeded_db(tmp_path)
+    _run(["classify", "--thread", "t-med", "--level", "sealed",
+          "--db", str(db_file)], monkeypatch)
+    capsys.readouterr()
+
+    out_file = tmp_path / "copy.db"
+    with pytest.raises(SystemExit) as exc:
+        _run(["export", str(out_file), "--db", str(db_file)], monkeypatch)
+    assert exc.value.code == 1
+    assert "SEALED" in capsys.readouterr().err
+    assert not out_file.exists()
+
+    _run(["export", str(out_file), "--include-sealed", "--db", str(db_file)],
+         monkeypatch)
+    assert "copied" in capsys.readouterr().out
+    assert out_file.exists()

--- a/tests/test_mcp_sealed.py
+++ b/tests/test_mcp_sealed.py
@@ -1,0 +1,107 @@
+"""Sealed content must be unreachable through every MCP tool, in every
+configuration — including include_private=True. Each sealed row carries a
+sentinel string; if it ever appears in a tool's JSON output, the wall leaked."""
+
+import json
+
+import pytest
+
+from mychatarchive.backends.storage import sqlite as store
+from mychatarchive.config import get_embedding_dim
+from mychatarchive.mcp import server
+
+DIM = get_embedding_dim()
+SENTINEL = "SEALED_SENTINEL_XYZ"
+PRIVATE_MARK = "PRIVATE_MARK_ABC"
+
+
+def _vec(seed: float) -> list[float]:
+    return [seed] * DIM
+
+
+@pytest.fixture
+def mcp_env(tmp_path, monkeypatch):
+    db_path = tmp_path / "archive.sqlite"
+    con = store.get_connection(db_path)
+    store.ensure_schema(con)
+
+    for tid, seed, text in (
+        ("pub", 0.5, "ordinary public conversation"),
+        ("priv", 0.5, f"quiet {PRIVATE_MARK} conversation"),
+        ("seal", 0.5, f"never surface {SENTINEL} anywhere"),
+    ):
+        store.insert_message(con, f"m-{tid}", tid, "chatgpt", "main",
+                             "2024-01-01T00:00:00", "user", text, f"T-{tid}", "s")
+        store.insert_chunk(con, f"c-{tid}", f"m-{tid}", tid, 0, text,
+                           "2024-01-01T00:00:00", "2024-01-01T00:00:00",
+                           _vec(seed), {"role": "user", "title": f"T-{tid}"})
+        store.insert_thread_summary(
+            con, f"{tid}::0000", tid, 0, f"T-{tid}", "chatgpt", 1, 50,
+            "2024-01-01T00:00:00", "2024-01-01T00:00:00",
+            f"summary: {text}", ["topic"], "test-model", "2024-01-01T00:00:00")
+        store.insert_thread_summary_embedding(con, f"{tid}::0000", _vec(seed))
+        store.insert_thought(con, f"th-{tid}", f"thought: {text}",
+                             "2024-01-01T00:00:00", _vec(seed))
+    con.commit()
+    store.set_thread_sensitivity(con, ["priv"], "private")
+    store.set_thread_sensitivity(con, ["seal"], "sealed")
+    con.execute("UPDATE thoughts SET sensitivity='private' WHERE thought_id='th-priv'")
+    con.execute("UPDATE thoughts SET sensitivity='sealed' WHERE thought_id='th-seal'")
+    con.commit()
+
+    monkeypatch.setattr(server, "_con", con)
+    monkeypatch.setattr(server, "_lazy_embed", lambda text: _vec(0.5))
+    yield con
+    con.close()
+
+
+def _all_tool_outputs(include_private: bool) -> list[str]:
+    """Run every content-returning MCP tool and collect raw JSON output."""
+    return [
+        server.search_brain("anything", limit=50, include_private=include_private),
+        server.search_recent(hours=24 * 365 * 20, limit=50,
+                             include_private=include_private),
+        server.get_context("anything", limit=50, include_private=include_private),
+        server.get_profile(days_back=365 * 20, include_private=include_private),
+    ]
+
+
+@pytest.mark.parametrize("include_private", [False, True])
+def test_sealed_sentinel_never_appears(mcp_env, include_private):
+    for output in _all_tool_outputs(include_private):
+        assert SENTINEL not in output
+
+
+def test_private_gated_by_include_private(mcp_env):
+    for output in _all_tool_outputs(include_private=False):
+        assert PRIVATE_MARK not in output
+    combined = "".join(_all_tool_outputs(include_private=True))
+    assert PRIVATE_MARK in combined
+
+
+def test_capture_thought_rejects_sealed(mcp_env):
+    con = mcp_env
+    before = con.execute("SELECT count(*) FROM thoughts").fetchone()[0]
+    out = json.loads(server.capture_thought("secret", sensitivity="sealed"))
+    assert "error" in out
+    assert con.execute("SELECT count(*) FROM thoughts").fetchone()[0] == before
+
+
+def test_capture_thought_private_roundtrip(mcp_env):
+    con = mcp_env
+    out = json.loads(server.capture_thought("a private idea", sensitivity="private"))
+    assert out["status"] == "captured"
+    row = con.execute(
+        "SELECT sensitivity FROM thoughts WHERE thought_id = ?",
+        (out["thought_id"],),
+    ).fetchone()
+    assert row[0] == "private"
+    # Invisible by default, visible with include_private
+    assert "a private idea" not in server.search_recent(hours=24)
+    assert "a private idea" in server.search_recent(hours=24, include_private=True)
+
+
+def test_scope_helper_cannot_express_sealed(mcp_env):
+    assert server._scope(False) == ("public",)
+    assert server._scope(True) == ("public", "private")
+    assert "sealed" not in server._scope(True)

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -2,7 +2,6 @@
 populated database, fail-closed scope defaults across the data access layer,
 and thread-level classification helpers."""
 
-import tempfile
 from pathlib import Path
 
 import pytest

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -1,0 +1,324 @@
+"""Tests for the v0.4.0 sensitivity layer: the schema-v3 migration on a
+populated database, fail-closed scope defaults across the data access layer,
+and thread-level classification helpers."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mychatarchive.backends.storage import sqlite as store
+from mychatarchive.config import get_embedding_dim
+
+DIM = get_embedding_dim()
+
+
+def _vec(seed: float) -> list[float]:
+    return [seed] * DIM
+
+
+@pytest.fixture
+def env(tmp_path):
+    """Fresh archive in an isolated directory (backups land next to the db)."""
+    db_path = tmp_path / "archive.sqlite"
+    con = store.get_connection(db_path)
+    store.ensure_schema(con)
+    yield con, db_path, tmp_path
+    con.close()
+
+
+def _msg(con, mid, thread, text, ts="2024-01-01T00:00:00", platform="chatgpt"):
+    store.insert_message(con, mid, thread, platform, "main", ts, "user", text,
+                         f"Title {thread}", "src")
+    con.commit()
+
+
+def _seed_three_levels(con):
+    """One thread per level, each with a message + chunk + summary, plus one
+    thought per level. Sealed/private set via the real classification path."""
+    for tid, seed in (("pub", 0.1), ("priv", 0.2), ("seal", 0.9)):
+        _msg(con, f"m-{tid}", tid, f"{tid} SECRET-{tid.upper()} content")
+        store.insert_chunk(con, f"c-{tid}", f"m-{tid}", tid, 0,
+                           f"{tid} SECRET-{tid.upper()} content",
+                           "2024-01-01T00:00:00", "2024-01-01T00:00:00",
+                           _vec(seed), {"role": "user", "title": f"Title {tid}"})
+        store.insert_thread_summary(
+            con, f"{tid}::0000", tid, 0, f"Title {tid}", "chatgpt", 1, 100,
+            "2024-01-01T00:00:00", "2024-01-01T00:00:00",
+            f"summary of {tid} SECRET-{tid.upper()}", ["topic"], "test-model",
+            "2024-01-01T00:00:00",
+        )
+        store.insert_thread_summary_embedding(con, f"{tid}::0000", _vec(seed))
+        store.insert_thought(con, f"th-{tid}", f"thought SECRET-{tid.upper()}",
+                             "2024-01-01T00:00:00", _vec(seed))
+    con.commit()
+    store.set_thread_sensitivity(con, ["priv"], "private")
+    store.set_thread_sensitivity(con, ["seal"], "sealed")
+    con.execute("UPDATE thoughts SET sensitivity='private' WHERE thought_id='th-priv'")
+    con.execute("UPDATE thoughts SET sensitivity='sealed' WHERE thought_id='th-seal'")
+    con.commit()
+
+
+# ── Migration on a populated database ─────────────────────────────────────────
+
+_V2_SCHEMA = """
+CREATE TABLE messages (
+    message_id TEXT PRIMARY KEY, canonical_thread_id TEXT NOT NULL,
+    platform TEXT NOT NULL, account_id TEXT NOT NULL, ts TEXT NOT NULL,
+    role TEXT NOT NULL, text TEXT NOT NULL, title TEXT, source_id TEXT NOT NULL
+);
+CREATE TABLE chunks (
+    chunk_id TEXT PRIMARY KEY, message_id TEXT, canonical_thread_id TEXT NOT NULL,
+    chunk_index INTEGER NOT NULL, text TEXT NOT NULL, ts_start TEXT, ts_end TEXT, meta TEXT
+);
+CREATE TABLE thoughts (
+    thought_id TEXT PRIMARY KEY, text TEXT NOT NULL, created_at TEXT NOT NULL, meta TEXT
+);
+CREATE TABLE thread_summaries (
+    summary_id TEXT PRIMARY KEY, canonical_thread_id TEXT NOT NULL,
+    segment_index INTEGER NOT NULL DEFAULT 0, title TEXT, platform TEXT,
+    message_count INTEGER, segment_chars INTEGER, ts_start TEXT, ts_end TEXT,
+    summary TEXT NOT NULL, key_topics TEXT, summary_model TEXT NOT NULL,
+    created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+);
+INSERT INTO messages VALUES ('m1','t1','chatgpt','main','2024-01-01','user','hello','T','s');
+INSERT INTO chunks VALUES ('c1','m1','t1',0,'hello','2024-01-01','2024-01-01','{}');
+INSERT INTO thoughts VALUES ('th1','a thought','2024-01-01','{}');
+INSERT INTO thread_summaries VALUES
+    ('t1::0000','t1',0,'T','chatgpt',1,5,'2024-01-01','2024-01-01','sum','[]','m','2024-01-01','2024-01-01');
+"""
+
+
+def _build_v2_db(tmp_path: Path):
+    db_path = tmp_path / "old.sqlite"
+    con = store.get_connection(db_path)
+    con.executescript(_V2_SCHEMA)
+    con.commit()
+    return con, db_path
+
+
+def test_migration_adds_column_and_defaults_public(tmp_path):
+    con, db_path = _build_v2_db(tmp_path)
+    store.ensure_schema(con)
+
+    for table in ("messages", "chunks", "thoughts", "thread_summaries"):
+        cols = {r[1] for r in con.execute(f"PRAGMA table_info({table})").fetchall()}
+        assert "sensitivity" in cols, table
+        rows = con.execute(f"SELECT sensitivity FROM {table}").fetchall()
+        assert rows and all(r[0] == "public" for r in rows), table
+
+    # No data loss
+    assert con.execute("SELECT count(*) FROM messages").fetchone()[0] == 1
+    assert con.execute("SELECT count(*) FROM chunks").fetchone()[0] == 1
+
+    version = con.execute(
+        "SELECT value FROM archive_meta WHERE key='schema_version'"
+    ).fetchone()[0]
+    assert version == "3"
+    con.close()
+
+
+def test_migration_creates_verified_backup_and_is_idempotent(tmp_path):
+    con, db_path = _build_v2_db(tmp_path)
+    store.ensure_schema(con)
+
+    backups = list(tmp_path.glob("old.pre-v3-*.backup.sqlite"))
+    assert len(backups) == 1
+    assert backups[0].stat().st_size > 0
+
+    # Second run: no new backup, no error
+    store.ensure_schema(con)
+    assert len(list(tmp_path.glob("old.pre-v3-*.backup.sqlite"))) == 1
+    con.close()
+
+
+def test_fresh_db_never_creates_backup(env):
+    con, db_path, tmp_path = env
+    assert list(tmp_path.glob("*.backup.sqlite")) == []
+
+
+def test_backup_failure_refuses_migration(tmp_path, monkeypatch):
+    con, db_path = _build_v2_db(tmp_path)
+
+    def _no_connect(*a, **kw):
+        raise OSError("disk full")
+
+    # The backup destination is opened via the backend module's sqlite3.connect.
+    monkeypatch.setattr(store.sqlite3, "connect", _no_connect)
+    with pytest.raises(Exception):
+        store.ensure_schema(con)
+
+    cols = {r[1] for r in con.execute("PRAGMA table_info(messages)").fetchall()}
+    assert "sensitivity" not in cols  # migration must not proceed unbacked-up
+    con.close()
+
+
+# ── Fail-closed scope defaults ────────────────────────────────────────────────
+
+def test_search_chunks_defaults_to_public_only(env):
+    con, *_ = env
+    _seed_three_levels(con)
+    ids = {c for c, _ in store.search_chunks(con, _vec(0.9), limit=10)}
+    assert ids == {"c-pub"}
+    ids = {c for c, _ in store.search_chunks(
+        con, _vec(0.9), limit=10, scope=("public", "private"))}
+    assert ids == {"c-pub", "c-priv"}
+    ids = {c for c, _ in store.search_chunks(
+        con, _vec(0.9), limit=10, scope=store.SENSITIVITY_LEVELS)}
+    assert "c-seal" in ids
+
+
+def test_fts_search_defaults_to_public_only(env):
+    con, *_ = env
+    _seed_three_levels(con)
+    assert all(r[2] == "pub" for r in store.fts_search(con, "SECRET"))
+    threads = {r[2] for r in store.fts_search(con, "SECRET", scope=("public", "private"))}
+    assert threads == {"pub", "priv"}
+    threads = {r[2] for r in store.fts_search(con, "SECRET", scope=store.SENSITIVITY_LEVELS)}
+    assert threads == {"pub", "priv", "seal"}
+
+
+def test_fts_search_empty_group_set_returns_nothing(env):
+    con, *_ = env
+    _seed_three_levels(con)
+    assert store.fts_search(con, "SECRET", group_thread_ids=set(),
+                            scope=store.SENSITIVITY_LEVELS) == []
+
+
+def test_recent_chunks_scoped_in_both_branches(env):
+    con, *_ = env
+    _seed_three_levels(con)
+    # no-platform branch (no JOIN)
+    ids = {r[0] for r in store.get_recent_chunks(con, "2020-01-01")}
+    assert ids == {"c-pub"}
+    # platform branch (JOIN messages)
+    ids = {r[0] for r in store.get_recent_chunks(con, "2020-01-01", platform="chatgpt")}
+    assert ids == {"c-pub"}
+    ids = {r[0] for r in store.get_recent_chunks(
+        con, "2020-01-01", platform="chatgpt", scope=store.SENSITIVITY_LEVELS)}
+    assert ids == {"c-pub", "c-priv", "c-seal"}
+
+
+def test_direct_id_lookups_enforce_scope(env):
+    con, *_ = env
+    _seed_three_levels(con)
+    assert store.get_chunk_by_id(con, "c-seal") is None
+    assert store.get_thought_by_id(con, "th-seal") is None
+    assert store.get_summary_by_id(con, "seal::0000") is None
+    assert store.get_thread_summary(con, "seal") is None
+    assert store.get_thread_summaries(con, "seal") == []
+    # Explicit full scope reaches them (CLI-only path)
+    assert store.get_chunk_by_id(con, "c-seal", scope=store.SENSITIVITY_LEVELS) is not None
+    assert store.get_chunk_by_id(con, "c-priv", scope=("public", "private")) is not None
+
+
+def test_thoughts_and_summary_search_scoped(env):
+    con, *_ = env
+    _seed_three_levels(con)
+    ids = {t for t, _ in store.search_thoughts(con, _vec(0.9), limit=10)}
+    assert ids == {"th-pub"}
+    ids = {s for s, _ in store.search_thread_summaries(con, _vec(0.9), limit=10)}
+    assert ids == {"pub::0000"}
+    ids = {r[0] for r in store.get_recent_thoughts(con, "2020-01-01")}
+    assert ids == {"th-pub"}
+
+
+def test_exports_scoped(env):
+    con, *_ = env
+    _seed_three_levels(con)
+    assert {m["thread_id"] for m in store.export_messages(con)} == {"pub"}
+    assert {t["thought_id"] for t in store.export_thoughts(con)} == {"th-pub"}
+    all_msgs = store.export_messages(con, scope=store.SENSITIVITY_LEVELS)
+    assert {m["thread_id"] for m in all_msgs} == {"pub", "priv", "seal"}
+    assert all("sensitivity" in m for m in all_msgs)
+
+
+def test_iter_threads_hides_mixed_threads_entirely(env):
+    con, *_ = env
+    _seed_three_levels(con)
+    # Add a second, public message to the private thread → mixed thread
+    _msg(con, "m-priv-2", "priv", "innocuous followup")
+    assert {t["canonical_thread_id"] for t in store.iter_threads(con)} == {"pub"}
+    in_scope = {t["canonical_thread_id"]: t["sensitivity"]
+                for t in store.iter_threads(con, scope=("public", "private"))}
+    assert set(in_scope) == {"pub", "priv"}
+    assert in_scope["priv"] == "private"
+
+
+def test_get_thread_messages_scoped(env):
+    con, *_ = env
+    _seed_three_levels(con)
+    assert store.get_thread_messages(con, "seal") == []
+    assert len(store.get_thread_messages(con, "seal",
+                                         scope=store.SENSITIVITY_LEVELS)) == 1
+
+
+def test_invalid_scope_raises(env):
+    con, *_ = env
+    _seed_three_levels(con)
+    with pytest.raises(ValueError):
+        store.search_chunks(con, _vec(0.1), scope=("public", "secret"))
+    with pytest.raises(ValueError):
+        store.fts_search(con, "SECRET", scope=())
+    with pytest.raises(ValueError):
+        store.insert_thought(con, "x", "t", "2024-01-01", _vec(0.1),
+                             sensitivity="classified")
+
+
+def test_list_thread_summaries_accepts_platform_list(env):
+    con, *_ = env
+    _seed_three_levels(con)
+    # Regression: get_profile passes a parsed list; single-equality broke this.
+    rows = store.list_thread_summaries(con, platform=["chatgpt", "anthropic"],
+                                       scope=store.SENSITIVITY_LEVELS)
+    assert {r[1] for r in rows} == {"pub", "priv", "seal"}
+
+
+# ── Classification helpers ────────────────────────────────────────────────────
+
+def test_set_thread_sensitivity_cascades_and_counts(env):
+    con, *_ = env
+    _seed_three_levels(con)
+    counts = store.set_thread_sensitivity(con, ["pub"], "private")
+    assert counts == {"messages": 1, "chunks": 1, "thread_summaries": 1}
+    assert store.get_thread_sensitivity(con, "pub") == ("private", 1)
+
+
+def test_sensitivity_counts_and_sealed_exists(env):
+    con, *_ = env
+    assert store.sealed_exists(con) is False
+    _seed_three_levels(con)
+    assert store.sealed_exists(con) is True
+    counts = store.sensitivity_counts(con)
+    assert counts["threads"] == {"public": 1, "private": 1, "sealed": 1}
+    assert counts["messages"]["sealed"] == 1
+
+
+def test_threads_before_uses_last_message(env):
+    con, *_ = env
+    _msg(con, "a1", "old", "x", ts="2020-01-01T00:00:00")
+    _msg(con, "b1", "spanning", "x", ts="2020-01-01T00:00:00")
+    _msg(con, "b2", "spanning", "x", ts="2025-01-01T00:00:00")
+    assert store.threads_before(con, "2024-01-01") == ["old"]
+
+
+def test_reconcile_raises_new_rows_to_thread_level(env):
+    con, *_ = env
+    _seed_three_levels(con)
+    # Re-sync adds a new message to the sealed thread — lands public by default
+    _msg(con, "m-seal-2", "seal", "newly imported into sealed thread")
+    row = con.execute(
+        "SELECT sensitivity FROM messages WHERE message_id='m-seal-2'"
+    ).fetchone()
+    assert row[0] == "public"
+
+    raised = store.reconcile_thread_sensitivity(con)
+    assert raised == 1
+    row = con.execute(
+        "SELECT sensitivity FROM messages WHERE message_id='m-seal-2'"
+    ).fetchone()
+    assert row[0] == "sealed"
+
+    # All-public threads are never touched, and reconcile never lowers levels
+    assert store.reconcile_thread_sensitivity(con) == 0
+    assert store.get_thread_sensitivity(con, "pub") == ("public", 1)


### PR DESCRIPTION
## What this is

A sensitivity layer so the archive can hold years of everything while agents only retrieve what the owner allows. Three levels:

- **public** (default) — normal retrieval, any client
- **private** — returned only when a caller explicitly opts in (`include_private` on MCP tools, `--include-private` on the CLI)
- **sealed** — never returned by the MCP server under any circumstances; CLI-only behind `--include-sealed`

Closes the long-standing "Privacy flags" roadmap item.

## Design

- **Enforced in the data access layer, fail-closed.** Every content-returning function takes a keyword-only `scope` defaulting to `("public",)`. A tool that forgets to pass scope gets public content only — this automatically covers integrations that call `mychatarchive.db` directly (e.g. the Hermes plugin), not just the MCP handlers.
- **Sealed is unrepresentable over MCP.** Tools express scope as a boolean `include_private`; a server-side allowlist strips `sealed` defensively even if a future edit widens the input. `capture_thought` rejects `sensitivity="sealed"`.
- **Thread-scoped classification.** `sensitivity` is denormalized onto messages, chunks, thoughts, and summaries (vec0 tables can't carry filter columns, so vector search over-fetches and post-filters). Bulk operations classify whole threads — one matching message classifies the conversation.
- **Migration backs up first.** `ALTER TABLE` on a populated archive only runs after a verified backup via the SQLite backup API (WAL-safe; a file copy would drop uncommitted frames). Idempotent; `BEGIN IMMEDIATE` guards concurrent openers; fresh installs get the column via DDL and never back up. Read paths (serve/search/export) now run `ensure_schema` so pre-v3 archives migrate on first use, with a clear error on read-only mounts.
- **Egress control.** `summarize` — the one command that sends raw content to an external LLM API — is public-only by default, `--include-private` opts in, sealed never leaves the machine. Re-running `sync` on a classified thread raises newly imported rows to the thread's level before anything can read them.

## Behavior changes

- `search` and `export` now return public content only by default (nothing is hidden that you didn't classify).
- `export --format sqlite` is refused when sealed rows exist unless `--include-sealed` (a file copy can't be filtered); it also checkpoints WAL before copying now.
- Fixed in passing: `fts_search` fail-open on empty group sets; `get_profile` returning zero summaries for comma-separated platform lists.

## Not in this PR (deliberately)

Model-assisted auto-classification; encryption at rest (sealed text still exists unencrypted in the file, FTS index, and vectors — documented in SECURITY.md); a CLI selector for sealing individual thoughts; a full refresh of the stale StorageBackend protocol (touched surface updated only).

## Tests — 122 pass (30 new)

| Required category | Coverage |
|---|---|
| Migration on a populated db | column added, rows default public, no data loss, verified backup, idempotent (one backup), backup failure blocks the ALTER |
| Fail-closed when scope omitted | every scoped DAL function, both `get_recent_chunks` branches, direct-ID lookups, mixed-thread hiding, invalid levels raise |
| Sealed unreachable via every MCP tool | sentinel-seeded db; `search_brain`/`search_recent`/`get_context`/`get_profile` with `include_private` both false and true; `capture_thought` rejection |

Also verified against a real multi-GB archive, tens of thousands of messages, spanning years: full migration chain (contentless-FTS rebuild + archive_meta + v3) completed in seconds with a verified backup, and confirmed zero leakage through default search and MCP tools.

## Deploying to a NAS archive

See the new "Upgrading: sensitivity migration (v0.4.0)" section in `docs/nas-setup.md` — stop serve, pull, trigger the migration explicitly with `classify --list`, verify the `*.pre-v3-*.backup.sqlite` sibling, restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)