### PR TITLE
Fix search ranking regression + sensitivity durability on import

### DIFF
--- a/src/mychatarchive/backends/storage/__init__.py
+++ b/src/mychatarchive/backends/storage/__init__.py
@@ -33,6 +33,7 @@ class StorageBackend(Protocol):
         self, con, message_id: str, canonical_thread_id: str,
         platform: str, account_id: str, ts: str, role: str,
         text: str, title: str, source_id: str,
+        *, sensitivity: str = "public",
     ) -> bool: ...
 
     # Counts

--- a/src/mychatarchive/backends/storage/sqlite.py
+++ b/src/mychatarchive/backends/storage/sqlite.py
@@ -484,18 +484,24 @@ def ensure_schema(con: sqlite3.Connection):
 
 def insert_message(con: sqlite3.Connection, message_id: str, canonical_thread_id: str,
                    platform: str, account_id: str, ts: str, role: str, text: str,
-                   title: str, source_id: str) -> bool:
+                   title: str, source_id: str, *, sensitivity: str = "public") -> bool:
     """Insert a message. Returns True if inserted, False if duplicate.
 
     The external-content FTS index is maintained by the messages_fts_ai/au/ad
     triggers (see _create_messages_fts), so there is no manual FTS bookkeeping
     here. INSERT OR IGNORE that skips a duplicate does not fire the trigger.
+
+    sensitivity is set at insert time so a row entering an already-classified
+    thread is never briefly (or, after an interrupted import, permanently)
+    readable at a wider scope than its thread.
     """
+    _validate_level(sensitivity)
     cur = con.execute(
         "INSERT OR IGNORE INTO messages "
-        "(message_id, canonical_thread_id, platform, account_id, ts, role, text, title, source_id) "
-        "VALUES (?,?,?,?,?,?,?,?,?)",
-        (message_id, canonical_thread_id, platform, account_id, ts, role, text, title, source_id),
+        "(message_id, canonical_thread_id, platform, account_id, ts, role, text, title, source_id, "
+        "sensitivity) VALUES (?,?,?,?,?,?,?,?,?,?)",
+        (message_id, canonical_thread_id, platform, account_id, ts, role, text, title, source_id,
+         sensitivity),
     )
     return cur.rowcount > 0
 
@@ -690,6 +696,12 @@ def search_chunks(
 
     if sort_by_time:
         matched.sort(key=lambda x: x[1] or "", reverse=True)
+    else:
+        # The re-query above returns rows in table order, not KNN order, so
+        # relevance ranking must be restored before truncating to `limit` —
+        # otherwise the best match can be cut or buried. Every default search
+        # takes this path (scope=("public",) makes needs_filter true).
+        matched.sort(key=lambda x: x[2])
 
     return [(c, d) for c, ts, d in matched[:limit]]
 

--- a/src/mychatarchive/cli.py
+++ b/src/mychatarchive/cli.py
@@ -1095,6 +1095,12 @@ def _cmd_classify(args, db_path: Path):
             print(f"Thread '{args.thread}' not found.", file=sys.stderr)
             con.close()
             sys.exit(1)
+        if args.dry_run:
+            print(f"Thread {args.thread}: {current[0]} -> {args.level} "
+                  f"({current[1]} messages, plus their chunks and summaries)")
+            print("\nDry run - nothing changed.")
+            con.close()
+            return
         _warn_if_sealed()
         counts = db.set_thread_sensitivity(con, [args.thread], args.level)
         con.close()

--- a/src/mychatarchive/db.py
+++ b/src/mychatarchive/db.py
@@ -38,10 +38,11 @@ def ensure_schema(con) -> None:
 
 def insert_message(con, message_id: str, canonical_thread_id: str,
                    platform: str, account_id: str, ts: str, role: str,
-                   text: str, title: str, source_id: str) -> bool:
+                   text: str, title: str, source_id: str,
+                   *, sensitivity: str = "public") -> bool:
     return _b().insert_message(
         con, message_id, canonical_thread_id, platform, account_id,
-        ts, role, text, title, source_id,
+        ts, role, text, title, source_id, sensitivity=sensitivity,
     )
 
 

--- a/src/mychatarchive/ingest.py
+++ b/src/mychatarchive/ingest.py
@@ -73,6 +73,13 @@ def _flush_thread(
         norm_text(first_snip),
     ]))
 
+    # A re-import of an already-classified thread must never introduce rows at
+    # a wider scope than the thread itself — not even transiently, since a
+    # concurrent MCP server reads committed rows, and an interrupted import
+    # would otherwise leave them public permanently.
+    existing = db.get_thread_sensitivity(con, canonical_thread_id)
+    thread_level = existing[0] if existing else "public"
+
     inserted = 0
     duplicates = 0
     for msg in thread_messages:
@@ -89,7 +96,7 @@ def _flush_thread(
         was_inserted = db.insert_message(
             con, message_id, canonical_thread_id, platform, account_id,
             ts_iso, msg["role"] or "", msg["content"] or "",
-            msg["thread_title"], source_id,
+            msg["thread_title"], source_id, sensitivity=thread_level,
         )
 
         if was_inserted:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,6 +100,38 @@ def test_classify_dry_run_wins_over_confirm(tmp_path, monkeypatch, capsys):
     assert sealed == 0
 
 
+def test_classify_thread_dry_run_does_not_apply(tmp_path, monkeypatch, capsys):
+    # Regression: the single-thread branch ignored --dry-run and applied the
+    # change immediately, so a preview silently mutated the archive.
+    db_file = _seeded_db(tmp_path)
+
+    _run(["classify", "--thread", "t-px", "--level", "sealed", "--dry-run",
+          "--db", str(db_file)], monkeypatch)
+    out = capsys.readouterr().out
+    assert "Dry run" in out
+    assert "public -> sealed" in out  # preview still shows the intended change
+
+    con = sqlite3.connect(db_file)
+    levels = {r[0] for r in con.execute("SELECT sensitivity FROM messages")}
+    con.close()
+    assert levels == {"public"}, "dry run must not modify the archive"
+
+
+def test_classify_thread_applies_without_dry_run(tmp_path, monkeypatch, capsys):
+    db_file = _seeded_db(tmp_path)
+
+    _run(["classify", "--thread", "t-px", "--level", "sealed",
+          "--db", str(db_file)], monkeypatch)
+    assert "public -> sealed" in capsys.readouterr().out
+
+    con = sqlite3.connect(db_file)
+    rows = dict(con.execute(
+        "SELECT canonical_thread_id, sensitivity FROM messages"
+    ).fetchall())
+    con.close()
+    assert rows == {"t-px": "sealed", "t-code": "public"}
+
+
 def test_classify_before_is_thread_scoped_on_last_message(tmp_path, monkeypatch, capsys):
     db_file = _seeded_db(tmp_path)
 

--- a/tests/test_search_ranking.py
+++ b/tests/test_search_ranking.py
@@ -1,0 +1,110 @@
+"""Semantic search must return results best-match-first.
+
+Regression guard for the v0.4.0 filtered-path bug: making scope=("public",)
+the default routed every search through the post-KNN re-query, which returned
+rows in table order and truncated to `limit` without restoring distance order.
+
+These tests deliberately use hash-style chunk ids (the production format,
+sha1(message_id|index)) so chunk_id order is uncorrelated with distance. With
+sequential ids like c00/c01 the bug is invisible, because table order happens
+to match rank.
+"""
+
+import hashlib
+import math
+
+import pytest
+
+from mychatarchive.backends.storage import sqlite as store
+from mychatarchive.config import get_embedding_dim
+
+DIM = get_embedding_dim()
+N = 60
+
+
+def _chunk_id(rank: int) -> str:
+    return hashlib.sha1(f"msg{rank}|0".encode()).hexdigest()[:16]
+
+
+def _vec_at_angle(degrees: float) -> list[float]:
+    """Unit vector `degrees` away from the query axis. Cosine distance grows
+    with the angle, so rank 0 (0 degrees) is nearest."""
+    theta = math.radians(degrees)
+    v = [0.0] * DIM
+    v[0] = math.cos(theta)
+    v[1] = math.sin(theta)
+    return v
+
+
+@pytest.fixture
+def ranked_archive(tmp_path):
+    """Archive where semantic rank is known: rank r sits r*1.5 degrees out."""
+    con = store.get_connection(tmp_path / "archive.sqlite")
+    store.ensure_schema(con)
+    for rank in range(N):
+        store.insert_message(con, f"m{rank}", f"t{rank}", "chatgpt", "main",
+                             "2024-01-01T00:00:00", "user", f"text {rank}", "T", "s")
+        store.insert_chunk(con, _chunk_id(rank), f"m{rank}", f"t{rank}", 0,
+                           f"text {rank}", "2024-01-01T00:00:00", "2024-01-01T00:00:00",
+                           _vec_at_angle(rank * 1.5), {"role": "user", "title": "T"})
+    con.commit()
+    yield con
+    con.close()
+
+
+def _query():
+    return _vec_at_angle(0)
+
+
+def _ranks(results):
+    by_id = {_chunk_id(r): r for r in range(N)}
+    return [by_id[cid] for cid, _ in results]
+
+
+def test_default_scope_returns_best_matches_in_order(ranked_archive):
+    # The default scope makes needs_filter true, so this exercises the
+    # filtered path — the one that used to lose ranking.
+    results = store.search_chunks(ranked_archive, _query(), limit=5)
+    assert _ranks(results) == [0, 1, 2, 3, 4]
+
+
+def test_full_scope_fast_path_returns_best_matches_in_order(ranked_archive):
+    results = store.search_chunks(ranked_archive, _query(), limit=5,
+                                  scope=store.SENSITIVITY_LEVELS)
+    assert _ranks(results) == [0, 1, 2, 3, 4]
+
+
+def test_distances_ascend_with_rank(ranked_archive):
+    results = store.search_chunks(ranked_archive, _query(), limit=10)
+    distances = [d for _, d in results]
+    assert distances == sorted(distances), "results must be ordered best-first"
+
+
+def test_ranking_holds_with_other_filters(ranked_archive):
+    # platform triggers the messages JOIN; cutoff triggers the ts predicate.
+    results = store.search_chunks(ranked_archive, _query(), limit=5,
+                                  platform="chatgpt", cutoff_iso="2020-01-01T00:00:00")
+    assert _ranks(results) == [0, 1, 2, 3, 4]
+
+
+def test_sort_by_time_still_sorts_by_time(ranked_archive):
+    # sort_by_time is an explicit override of relevance order, so newest wins
+    # even when that inverts the distance ranking. Timestamps go on the three
+    # nearest chunks so they are inside the KNN candidate pool.
+    con = ranked_archive
+    for rank, ts in ((0, "2025-01-01T00:00:00"), (1, "2025-02-01T00:00:00"),
+                     (2, "2025-03-01T00:00:00")):
+        con.execute("UPDATE chunks SET ts_start = ? WHERE chunk_id = ?",
+                    (ts, _chunk_id(rank)))
+    con.commit()
+    results = store.search_chunks(con, _query(), limit=3, sort_by_time=True)
+    # Distance order would be [0, 1, 2]; newest-first must invert it.
+    assert _ranks(results) == [2, 1, 0]
+
+
+def test_private_content_excluded_without_widening_scope(ranked_archive):
+    # Ranking fix must not weaken the fail-closed scope filter.
+    con = ranked_archive
+    store.set_thread_sensitivity(con, ["t0", "t1"], "private")
+    results = store.search_chunks(con, _query(), limit=5)
+    assert _ranks(results) == [2, 3, 4, 5, 6]

--- a/tests/test_sensitivity_durability.py
+++ b/tests/test_sensitivity_durability.py
@@ -1,0 +1,135 @@
+"""Rows entering a classified thread must be classified at insert time.
+
+Regression guard: reconcile_thread_sensitivity runs once at the end of an
+import, but _flush_thread commits per thread. Relying on reconcile alone meant
+new rows in a sealed thread were committed as 'public' and readable by a
+concurrent MCP server for the rest of the import — permanently if the import
+was interrupted before the reconcile ran.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mychatarchive import db, ingest
+from mychatarchive.backends.storage import sqlite as store
+
+SENTINEL = "project-x rollout decision"
+
+
+def _chatgpt_export(messages):
+    """Minimal ChatGPT-format export: one conversation, given messages."""
+    mapping = {}
+    for i, (role, text, ts) in enumerate(messages):
+        mapping[f"n_{i}"] = {
+            "message": {
+                "author": {"role": role},
+                "content": {"content_type": "text", "parts": [text]},
+                "create_time": ts,
+            }
+        }
+    return [{"id": "conv1", "title": "Planning", "mapping": mapping}]
+
+
+def _write_json(data) -> Path:
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False,
+                                    encoding="utf-8")
+    json.dump(data, f)
+    f.close()
+    return Path(f.name)
+
+
+FIRST_PASS = [("user", "kickoff notes", 1700000000.0),
+              ("assistant", "understood", 1700000060.0)]
+# Same first message => same canonical_thread_id => a genuine re-import.
+SECOND_PASS = FIRST_PASS + [("user", SENTINEL, 1700000120.0)]
+
+
+@pytest.fixture
+def sealed_archive(tmp_path):
+    """Archive with one thread, imported then sealed."""
+    db_path = tmp_path / "archive.sqlite"
+    ingest.run(_write_json(_chatgpt_export(FIRST_PASS)), db_path, format_name="chatgpt")
+
+    con = db.get_connection(db_path)
+    thread_id = con.execute(
+        "SELECT canonical_thread_id FROM messages LIMIT 1"
+    ).fetchone()[0]
+    db.set_thread_sensitivity(con, [thread_id], "sealed")
+    con.close()
+    return db_path, thread_id
+
+
+def _levels(db_path):
+    con = db.get_connection(db_path)
+    rows = con.execute("SELECT text, sensitivity FROM messages").fetchall()
+    con.close()
+    return dict(rows)
+
+
+def test_reimport_into_sealed_thread_inserts_sealed(sealed_archive):
+    db_path, _ = sealed_archive
+    ingest.run(_write_json(_chatgpt_export(SECOND_PASS)), db_path,
+               format_name="chatgpt")
+
+    levels = _levels(db_path)
+    assert SENTINEL in levels, "the new message should have been imported"
+    assert levels[SENTINEL] == "sealed"
+    assert set(levels.values()) == {"sealed"}
+
+
+def test_interrupted_import_leaves_no_public_rows(sealed_archive, monkeypatch):
+    """Crash between the per-thread commit and the end-of-run reconcile."""
+    db_path, _ = sealed_archive
+
+    def _boom(con):
+        raise KeyboardInterrupt("simulated interrupt after flush")
+
+    monkeypatch.setattr(db, "reconcile_thread_sensitivity", _boom)
+
+    with pytest.raises(KeyboardInterrupt):
+        ingest.run(_write_json(_chatgpt_export(SECOND_PASS)), db_path,
+                   format_name="chatgpt")
+
+    # The row is committed (per-thread flush) but must already be sealed —
+    # reconcile never ran, so insert-time classification is the only guard.
+    levels = _levels(db_path)
+    assert levels.get(SENTINEL) == "sealed"
+    assert "public" not in levels.values()
+
+
+def test_interrupted_import_content_not_searchable(sealed_archive, monkeypatch):
+    """The real consequence: an interrupted sync must not expose the content."""
+    db_path, _ = sealed_archive
+    monkeypatch.setattr(db, "reconcile_thread_sensitivity",
+                        lambda con: (_ for _ in ()).throw(KeyboardInterrupt()))
+
+    with pytest.raises(KeyboardInterrupt):
+        ingest.run(_write_json(_chatgpt_export(SECOND_PASS)), db_path,
+                   format_name="chatgpt")
+
+    con = db.get_connection(db_path)
+    assert store.fts_search(con, "project-x") == []          # default scope
+    assert store.fts_search(con, "project-x",
+                            scope=store.SENSITIVITY_LEVELS)   # exists when asked
+    con.close()
+
+
+def test_private_thread_inheritance(tmp_path):
+    db_path = tmp_path / "archive.sqlite"
+    ingest.run(_write_json(_chatgpt_export(FIRST_PASS)), db_path, format_name="chatgpt")
+    con = db.get_connection(db_path)
+    thread_id = con.execute("SELECT canonical_thread_id FROM messages LIMIT 1").fetchone()[0]
+    db.set_thread_sensitivity(con, [thread_id], "private")
+    con.close()
+
+    ingest.run(_write_json(_chatgpt_export(SECOND_PASS)), db_path, format_name="chatgpt")
+    assert _levels(db_path)[SENTINEL] == "private"
+
+
+def test_unclassified_threads_still_import_public(tmp_path):
+    db_path = tmp_path / "archive.sqlite"
+    ingest.run(_write_json(_chatgpt_export(SECOND_PASS)), db_path, format_name="chatgpt")
+    assert set(_levels(db_path).values()) == {"public"}


### PR DESCRIPTION
Three fixes from the post-v0.4.0 review. Each has a regression test, and each test was verified to fail without its fix.

## 1. Semantic search lost relevance ranking (`sqlite.py`)

Making `scope=("public",)` the default in v0.4.0 meant every search stopped taking the fast path and started taking the post-KNN re-query path — which returns rows in table order and truncated to `limit` without ever restoring distance order. The best match could be buried mid-list or cut entirely.

With production-style hash chunk ids, a top-5 came back as ranks `[3, 9, 19, 21, 0]` instead of `[0, 1, 2, 3, 4]` — best match last, three of the true top-5 missing. Per-result similarity values stayed individually correct, so output read as `Result 1 (similarity: 0.9969)` above `Result 5 (similarity: 1.0)`.

Affected `search_brain`, `get_context`, CLI semantic search, and plugin prefetch. Keyword/FTS search was unaffected (it orders by bm25 in SQL).

**Fix:** sort by distance before truncating, when not sorting by time.

**Test note:** `tests/test_search_ranking.py` uses sha1-style chunk ids deliberately. With sequential ids (`c00`, `c01`, …) chunk-id order coincides with rank and the bug is invisible — that is exactly why the v0.4.0 suite missed it. The suite also now asserts that `sort_by_time` still overrides relevance, and that the ranking fix did not weaken scope filtering.

## 2. Rows entering a classified thread were public until the end of the import (`ingest.py`)

`_flush_thread` commits per thread, but `reconcile_thread_sensitivity` only ran once at the end of `run()`. So messages imported into an already-sealed thread were committed as `public` for the remainder of the import — readable by a concurrently running MCP server — and stayed public permanently if the import was interrupted before the reconcile.

**Fix:** `insert_message` takes `sensitivity`; `_flush_thread` resolves the thread's existing level once and inserts at it. The end-of-run reconcile stays as a backstop for rows predating this change.

**Tests:** cover the interrupted case (reconcile raising mid-import) and assert the content is not reachable via default-scope search afterwards, plus private-level inheritance and the unclassified-thread path.

## 3. `classify --thread --dry-run` applied the change anyway (`cli.py`)

The single-thread branch never checked `args.dry_run`, so a preview mutated and committed — the one flag whose entire purpose is to not do that. It now prints the same before/after preview as the bulk selectors and returns without writing.

## Verification

- 135 tests pass (13 new).
- `ruff check src/ tests/` error count unchanged from main; new test files are clean.
- Each fix was reverted in isolation to confirm its tests fail without it: 4/6 ranking tests, 2/5 durability tests, 1/2 dry-run tests.

Found by a multi-agent review of `9b0906b`. The remaining review findings are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)