### PR TITLE
Fix silent data loss on import: unparseable timestamps and Claude Code detection

### DIFF
--- a/src/mychatarchive/ingest.py
+++ b/src/mychatarchive/ingest.py
@@ -52,13 +52,20 @@ def _flush_thread(
     platform: str,
     account_id: str,
     source_id: str,
-) -> tuple[int, int]:
-    """Insert one thread's messages. Returns (inserted, duplicates).
+) -> tuple[int, int, int, str | None]:
+    """Insert one thread's messages. Returns (inserted, duplicates, skipped,
+    skipped_example).
 
     canonical_thread_id derives from the thread's chronologically-first
     message, and message_ids derive from the canonical id — identical to the
     pre-streaming implementation, so re-importing an export produced under
     either version dedups cleanly.
+
+    A message whose created_at can't be turned into a timestamp (parser
+    yielded 0.0 for an unparseable/missing source timestamp) is skipped
+    rather than inserted with a fabricated time. skipped_example carries the
+    thread_title of the first such message so callers can report one
+    concrete example instead of a per-message warning.
     """
     thread_messages.sort(key=lambda m: m["created_at"])
     first = thread_messages[0]
@@ -82,6 +89,8 @@ def _flush_thread(
 
     inserted = 0
     duplicates = 0
+    skipped = 0
+    skipped_example = None
     for msg in thread_messages:
         ts_round = round_epoch(msg["created_at"]) or 0
         message_id = sha1("|".join([
@@ -91,6 +100,9 @@ def _flush_thread(
 
         ts_iso = iso_from_epoch(msg["created_at"])
         if not ts_iso:
+            skipped += 1
+            if skipped_example is None:
+                skipped_example = msg.get("thread_title") or canonical_thread_id
             continue
 
         was_inserted = db.insert_message(
@@ -105,7 +117,7 @@ def _flush_thread(
             duplicates += 1
 
     con.commit()
-    return inserted, duplicates
+    return inserted, duplicates, skipped, skipped_example
 
 
 def run(
@@ -149,6 +161,8 @@ def run(
 
     inserted = 0
     duplicates = 0
+    skipped = 0
+    skipped_example = None
     threads_flushed = 0
     current_tid: str | None = None
     current: list[dict] = []
@@ -158,9 +172,14 @@ def run(
         for msg in parse(file_path, format_name):
             tid = msg["thread_id"]
             if current and tid != current_tid:
-                ins, dup = _flush_thread(con, current, platform, account_id, source_id)
+                ins, dup, skp, example = _flush_thread(
+                    con, current, platform, account_id, source_id
+                )
                 inserted += ins
                 duplicates += dup
+                skipped += skp
+                if skipped_example is None:
+                    skipped_example = example
                 threads_flushed += 1
                 progress.update(1)
                 current = []
@@ -168,9 +187,12 @@ def run(
             current.append(msg)
 
         if current:
-            ins, dup = _flush_thread(con, current, platform, account_id, source_id)
+            ins, dup, skp, example = _flush_thread(con, current, platform, account_id, source_id)
             inserted += ins
             duplicates += dup
+            skipped += skp
+            if skipped_example is None:
+                skipped_example = example
             threads_flushed += 1
             progress.update(1)
     finally:
@@ -198,6 +220,9 @@ def run(
     print(f"  Threads:    {threads_flushed}", file=sys.stderr)
     print(f"  Inserted:   {inserted}", file=sys.stderr)
     print(f"  Duplicates: {duplicates}", file=sys.stderr)
+    if skipped:
+        example = f" (e.g. '{skipped_example}')" if skipped_example else ""
+        print(f"  Skipped:    {skipped} — unparseable timestamp{example}", file=sys.stderr)
     print(f"  Total in DB: {total}", file=sys.stderr)
 
     return inserted, duplicates

--- a/src/mychatarchive/parsers/__init__.py
+++ b/src/mychatarchive/parsers/__init__.py
@@ -19,6 +19,57 @@ PARSERS = {
 
 DIRECTORY_PARSERS = {"claude_code", "cursor"}
 
+# Claude Code session .jsonl files interleave message records with
+# bookkeeping records; all of these `type` values are shapes the parser
+# already knows to either read or skip (see parsers/claude_code.py).
+_CLAUDE_CODE_JSONL_TYPES = {
+    "user", "assistant", "file-history-snapshot",
+    "queue-operation", "mode", "ai-title", "summary",
+}
+
+# A recognized `type` alone is too generic — other tools could plausibly emit
+# JSONL with {"type": "user", ...} lines. Require at least one of these
+# claude_code-specific fields too, so detection stays specific to real
+# session files rather than stealing any JSONL with a matching `type`.
+_CLAUDE_CODE_JSONL_MARKER_KEYS = {
+    "sessionId", "uuid", "parentUuid", "leafUuid", "cwd", "gitBranch", "version",
+}
+
+
+def _looks_like_claude_code_jsonl(p: Path, max_lines: int = 10) -> bool:
+    """Scan the first few non-empty lines of a .jsonl file for a
+    claude_code-shaped record.
+
+    Real Claude Code session files commonly lead with one or more bookkeeping
+    records (queue-operation, mode, ai-title, summary) before the first
+    user/assistant turn, so checking only the first line (the old behavior)
+    misses them and detection falls through to "unknown format".
+    """
+    checked = 0
+    try:
+        with open(p, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                checked += 1
+                if checked > max_lines:
+                    break
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                if (
+                    record.get("type") in _CLAUDE_CODE_JSONL_TYPES
+                    and _CLAUDE_CODE_JSONL_MARKER_KEYS & record.keys()
+                ):
+                    return True
+    except OSError:
+        return False
+    return False
+
 
 def detect_format(file_path: Path) -> str | None:
     """Auto-detect export format by inspecting the JSON structure.
@@ -37,15 +88,8 @@ def detect_format(file_path: Path) -> str | None:
         return None
 
     if p.suffix == ".jsonl":
-        with open(p, "r", encoding="utf-8", errors="ignore") as f:
-            first_line = f.readline().strip()
-        if first_line:
-            try:
-                record = json.loads(first_line)
-                if isinstance(record, dict) and record.get("type") in ("user", "assistant", "file-history-snapshot"):
-                    return "claude_code"
-            except json.JSONDecodeError:
-                pass
+        if _looks_like_claude_code_jsonl(p):
+            return "claude_code"
 
     if p.name == "state.vscdb":
         return "cursor"

--- a/tests/test_ingest_streaming.py
+++ b/tests/test_ingest_streaming.py
@@ -133,6 +133,37 @@ def test_anthropic_parser_streams():
         p.unlink(missing_ok=True)
 
 
+def test_unparseable_timestamp_is_counted_not_silently_dropped(tmp_db, capsys):
+    """A message whose source timestamp can't be parsed (parsers yield 0.0
+    for these — see anthropic.py / cursor.py) must not vanish from the
+    import summary. It should be counted as skipped, and inserted +
+    duplicates + skipped must account for every parsed message."""
+    data = [{
+        "uuid": "u1", "name": "Project-x convo",
+        "chat_messages": [
+            {"sender": "human", "text": "hello", "content": [],
+             "created_at": "2026-01-01T00:00:00Z"},
+            {"sender": "assistant", "text": "reply with a bad timestamp", "content": [],
+             "created_at": "not-a-real-date"},
+        ],
+    }]
+    export = _write_json(data)
+    try:
+        capsys.readouterr()  # clear
+        inserted, dupes = ingest.run(export, tmp_db, format_name="anthropic")
+        err = capsys.readouterr().err
+        assert inserted == 1
+        assert dupes == 0
+        assert "Skipped:    1" in err, "the skipped count must be surfaced in the summary"
+
+        total_parsed = 2
+        # No message may vanish: every parsed message is either inserted,
+        # a duplicate, or explicitly counted as skipped.
+        assert inserted + dupes + 1 == total_parsed
+    finally:
+        export.unlink(missing_ok=True)
+
+
 def test_grok_wrapped_conversations_streams():
     data = {"conversations": [{
         "conversation": {"id": "g1", "title": "Grok convo"},

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,9 +1,11 @@
 """Tests for parser auto-detection and parsing."""
 
+import json
 from pathlib import Path
 
 import pytest
 
+from mychatarchive import db, ingest
 from mychatarchive.parsers import detect_format, parse
 
 EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
@@ -44,3 +46,78 @@ def test_parse_grok():
 def test_auto_detect_parse():
     messages = list(parse(EXAMPLES_DIR / "sample_chatgpt.json"))
     assert len(messages) > 0
+
+
+def _write_jsonl(tmp_path: Path, lines: list[dict], name: str = "session.jsonl") -> Path:
+    p = tmp_path / name
+    with open(p, "w", encoding="utf-8") as f:
+        for line in lines:
+            f.write(json.dumps(line) + "\n")
+    return p
+
+
+def test_detect_claude_code_jsonl_with_leading_bookkeeping_records(tmp_path):
+    """Real Claude Code session files often lead with non-message records
+    (queue-operation, mode, ai-title, summary) before the first turn.
+    Detection must scan past them instead of giving up after line one."""
+    lines = [
+        {"type": "mode", "mode": "plan"},
+        {"type": "queue-operation", "op": "enqueue"},
+        {"type": "ai-title", "title": "Project-x session"},
+        {
+            "type": "user", "sessionId": "sess-1", "uuid": "u1",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "message": {"role": "user", "content": "hello there"},
+        },
+        {
+            "type": "assistant", "sessionId": "sess-1", "uuid": "u2",
+            "timestamp": "2026-01-01T00:00:30Z",
+            "message": {"role": "assistant", "content": "hi, how can I help?"},
+        },
+    ]
+    p = _write_jsonl(tmp_path, lines)
+    assert detect_format(p) == "claude_code"
+
+
+def test_claude_code_jsonl_full_ingest_skips_bookkeeping_records(tmp_path):
+    """A full ingest.run() on a real-shaped session file (auto-detected, no
+    --format) must import the actual turns and must not crash or emit
+    garbage rows for the non-message bookkeeping records."""
+    lines = [
+        {"type": "queue-operation", "sessionId": "sess-1", "op": "enqueue"},
+        {"type": "mode", "sessionId": "sess-1", "mode": "plan"},
+        {"type": "ai-title", "sessionId": "sess-1", "title": "Project-x session"},
+        {"type": "summary", "sessionId": "sess-1", "summary": "discussing project-x"},
+        {
+            "type": "user", "sessionId": "sess-1", "uuid": "u1",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "message": {"role": "user", "content": "hello there"},
+        },
+        {
+            "type": "assistant", "sessionId": "sess-1", "uuid": "u2",
+            "timestamp": "2026-01-01T00:00:30Z",
+            "message": {"role": "assistant", "content": "hi, how can I help?"},
+        },
+    ]
+    p = _write_jsonl(tmp_path, lines)
+    db_path = tmp_path / "archive.sqlite"
+
+    inserted, dupes = ingest.run(p, db_path)  # no format_name -> must auto-detect
+
+    assert inserted == 2, "only the two real turns should be imported"
+    assert dupes == 0
+    con = db.get_connection(db_path)
+    assert db.message_count(con) == 2
+    con.close()
+
+
+def test_generic_jsonl_with_type_field_not_misdetected_as_claude_code(tmp_path):
+    """A JSONL file that merely happens to use `type: user`/`assistant`
+    values but carries none of Claude Code's session metadata (sessionId,
+    uuid, cwd, ...) must not be claimed by the claude_code detector."""
+    lines = [
+        {"type": "user", "text": "hello"},
+        {"type": "assistant", "text": "hi"},
+    ]
+    p = _write_jsonl(tmp_path, lines, name="generic.jsonl")
+    assert detect_format(p) != "claude_code"


### PR DESCRIPTION
Two HIGH-severity findings from the post-v0.4.0 review. Both are silent data loss — the archive ends up incomplete and nothing tells you.

## 1. Messages with unparseable timestamps vanished from the summary (`ingest.py`)

`_flush_thread` dropped any message whose `created_at` could not be turned into a timestamp, and counted it as neither inserted nor duplicate. The import summary's Inserted/Duplicates therefore summed to less than the number of messages parsed, and the user had no way to know content was missing.

This is reachable in practice: `parsers/anthropic.py` yields `created_at=0.0` when a source timestamp fails to parse, and `parsers/cursor.py` does the same for bubbles missing `createdAt`.

**Fix:** count the skips and surface them — `Skipped: N — unparseable timestamp (e.g. '<thread title>')`, printed only when non-zero. Messages are still dropped rather than given fabricated timestamps; the change is that the loss is now visible.

## 2. Claude Code `.jsonl` session files were not detected (`parsers/__init__.py`)

Detection read only the **first** line and accepted a `type` of user/assistant/file-history-snapshot. Real session files commonly lead with bookkeeping records (`queue-operation`, `mode`, `ai-title`, `summary`), so detection failed, fell through to a JSON branch that errored, and returned `None`. Such a file was skipped on every sync with a one-line "unknown format" note, and `import session.jsonl` without `--format` always refused.

**Fix:** scan the first several non-empty lines and accept the file when a line has a recognized `type` **and** at least one Claude Code-specific key (`sessionId`, `uuid`, `parentUuid`, `cwd`, `gitBranch`, …). The marker-key requirement keeps detection from stealing unrelated JSONL that happens to contain `{"type": "user"}` — the old check was simultaneously too strict (first line only) and too loose (bare `type` match), and there is now a test for each direction.

Verified the existing `claude_code` parser already skips unknown record types, so no parser-side guard was needed.

## Tests

4 new tests; 139 pass total. Each fix was reverted in isolation to confirm its tests fail without it (verified independently of the agent that wrote them).

## Reviewer note

Two related issues were found but deliberately left out of scope: `chatgpt.py` and `claude_code.py` drop zero-timestamp messages *inside the parser*, before ingest can count them (same silent-loss pattern, two more files), and `run_directory`/`run_all` batch summaries don't aggregate the skipped total. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)