### PR TITLE
Harden the summarize pipeline: no data loss on --force, resumable threads, correct OpenAI dimensions

### DIFF
--- a/src/mychatarchive/backends/embeddings/openai.py
+++ b/src/mychatarchive/backends/embeddings/openai.py
@@ -28,6 +28,11 @@ _MODEL_DIMS: dict[str, int] = {
 _DEFAULT_MODEL = "text-embedding-3-small"
 _BATCH_SIZE = 2048  # OpenAI's max inputs per request
 
+# Only the newer -3 models accept the "dimensions" request param (Matryoshka
+# shortening); text-embedding-ada-002 always returns its fixed 1536 dims and
+# errors if "dimensions" is sent at all.
+_SUPPORTS_DIMENSIONS_PARAM = {"text-embedding-3-small", "text-embedding-3-large"}
+
 _client = None
 
 
@@ -71,9 +76,18 @@ def embed_texts(texts: list[str]) -> list[list[float]]:
     model = _get_model()
     results: list[list[float]] = []
 
+    # Request vectors sized to match what vec_chunks was actually built with
+    # (see dimension() below). Without this, the API always returns the
+    # model's native size regardless of the configured/table dimension, and
+    # the first insert into vec_chunks fails with a sqlite-vec dimension
+    # error after the batch has already been paid for.
+    kwargs = {}
+    if model in _SUPPORTS_DIMENSIONS_PARAM:
+        kwargs["dimensions"] = dimension()
+
     for i in range(0, len(texts), _BATCH_SIZE):
         batch = texts[i : i + _BATCH_SIZE]
-        response = client.embeddings.create(input=batch, model=model)
+        response = client.embeddings.create(input=batch, model=model, **kwargs)
         # API guarantees order matches input, but sort by index to be safe
         ordered = sorted(response.data, key=lambda item: item.index)
         results.extend(item.embedding for item in ordered)

--- a/src/mychatarchive/backends/storage/sqlite.py
+++ b/src/mychatarchive/backends/storage/sqlite.py
@@ -979,6 +979,24 @@ def has_thread_summary(con: sqlite3.Connection, canonical_thread_id: str) -> boo
     return row is not None
 
 
+def get_thread_summary_segment_counts(
+    con: sqlite3.Connection, canonical_thread_id: str
+) -> dict[int, int]:
+    """Return {segment_index: message_count} for every stored segment of a thread.
+
+    Used to detect partially-summarized threads and to decide, segment by
+    segment, whether a previously-written summary still matches the current
+    segmentation (same message_count) or must be regenerated because the
+    thread grew or messages_per_segment changed.
+    """
+    rows = con.execute(
+        "SELECT segment_index, message_count FROM thread_summaries "
+        "WHERE canonical_thread_id = ?",
+        (canonical_thread_id,),
+    ).fetchall()
+    return {r[0]: r[1] for r in rows}
+
+
 def insert_thread_summary(
     con: sqlite3.Connection,
     summary_id: str,

--- a/src/mychatarchive/config.py
+++ b/src/mychatarchive/config.py
@@ -89,8 +89,26 @@ def get_embedding_model() -> str:
 
 
 def get_embedding_dim() -> int:
+    """Effective embedding dimension — what vec_chunks (and friends) get sized to.
+
+    An explicit "dimension" in config always wins. Otherwise the sane default
+    depends on the embedder backend: 384 is the LOCAL sentence-transformers
+    model's dim, not a universal default. The OpenAI backend's models return
+    much larger vectors natively (1536 / 3072); defaulting an OpenAI-backend
+    archive to 384 built a table too small for what the API actually
+    returns, breaking the very first insert. text-embedding-ada-002 in
+    particular always returns 1536 and can't be Matryoshka-shortened via the
+    "dimensions" request param (see backends/embeddings/openai.py), so this
+    matters even after that param is wired up.
+    """
     cfg = load_config()
-    return cfg.get("embeddings", {}).get("dimension", _DEFAULT_EMBEDDING_DIM)
+    emb = cfg.get("embeddings", {})
+    if "dimension" in emb:
+        return int(emb["dimension"])
+    if emb.get("backend") == "openai":
+        from mychatarchive.backends.embeddings.openai import _DEFAULT_MODEL, _MODEL_DIMS
+        return _MODEL_DIMS.get(emb.get("model", _DEFAULT_MODEL), 1536)
+    return _DEFAULT_EMBEDDING_DIM
 
 
 def get_chunk_max_chars() -> int:

--- a/src/mychatarchive/db.py
+++ b/src/mychatarchive/db.py
@@ -185,6 +185,11 @@ def has_thread_summary(con, canonical_thread_id: str) -> bool:
     return _b().has_thread_summary(con, canonical_thread_id)
 
 
+def get_thread_summary_segment_counts(con, canonical_thread_id: str) -> dict:
+    """Return {segment_index: message_count} for a thread's stored segments."""
+    return _b().get_thread_summary_segment_counts(con, canonical_thread_id)
+
+
 def insert_thread_summary(
     con,
     summary_id: str,

--- a/src/mychatarchive/summarizer.py
+++ b/src/mychatarchive/summarizer.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import math
 import os
 import sys
 import urllib.error
@@ -82,6 +83,13 @@ def _segment_messages(messages: list[dict], per_segment: int) -> list[list[dict]
     if not messages:
         return []
     return [messages[i:i + per_segment] for i in range(0, len(messages), per_segment)]
+
+
+def _expected_segment_count(message_count: int, per_segment: int) -> int:
+    """How many segments a thread with message_count messages should have."""
+    if message_count <= 0 or per_segment <= 0:
+        return 0
+    return math.ceil(message_count / per_segment)
 
 
 def _segment_ts(messages: list[dict]) -> tuple[str | None, str | None]:
@@ -225,10 +233,19 @@ def run(
     print(f"  [summarize] {total:,} threads in scope {list(scope)}", file=sys.stderr)
 
     if not force:
-        threads = [t for t in threads if not db.has_thread_summary(con, t["canonical_thread_id"])]
-        print(f"  [summarize] {len(threads):,} without summaries", file=sys.stderr)
+        # A thread is "complete" only when it has as many stored segments as
+        # its current message count implies (see run() docstring / Bug 2 note
+        # below); anything else — never summarized, or interrupted partway
+        # through a previous run — is picked back up here.
+        def _incomplete(t: dict) -> bool:
+            expected = _expected_segment_count(t["message_count"], messages_per_segment)
+            have = len(db.get_thread_summary_segment_counts(con, t["canonical_thread_id"]))
+            return have != expected
+
+        threads = [t for t in threads if _incomplete(t)]
+        print(f"  [summarize] {len(threads):,} incomplete or unsummarized", file=sys.stderr)
     else:
-        print(f"  [summarize] --force: re-summarizing all", file=sys.stderr)
+        print("  [summarize] --force: re-summarizing all", file=sys.stderr)
 
     if limit:
         threads = threads[:limit]
@@ -264,13 +281,29 @@ def run(
             if not messages:
                 continue
 
-            if force:
-                db.delete_thread_summaries(con, thread_id)
-
             segments = _segment_messages(messages, messages_per_segment)
             n_segments = len(segments)
 
+            # Bug 2 (resumability): a segment already on disk with the same
+            # message_count is reused as-is rather than re-paid-for. force=True
+            # ignores prior segments entirely and regenerates every one. This
+            # correctly re-covers a thread that grew (its tail segment's
+            # message_count no longer matches) but is not foolproof against a
+            # messages_per_segment change that happens to leave the segment
+            # *count* unchanged — that edge case needs --force to fully repair.
+            existing_counts = {} if force else db.get_thread_summary_segment_counts(con, thread_id)
+
+            # Bug 1 (atomicity): generate every needed segment into memory
+            # first and touch the DB only once the whole thread has succeeded.
+            # If the API fails partway through, nothing for this thread is
+            # written or deleted here — under --force the pre-existing
+            # summaries are untouched; without --force the segments already
+            # on disk from an earlier run are untouched and still count next run.
+            new_segments = []
             for seg_idx, seg_messages in enumerate(segments):
+                if existing_counts.get(seg_idx) == len(seg_messages):
+                    continue  # unchanged since last run — don't re-pay for it
+
                 summary_id = f"{thread_id}::{seg_idx:04d}"
                 seg_ts_start, seg_ts_end = _segment_ts(seg_messages)
                 seg_chars = _segment_chars(seg_messages)
@@ -282,33 +315,64 @@ def run(
                 if not summary:
                     raise ValueError("Empty summary returned")
 
-                db.insert_thread_summary(
-                    con,
-                    summary_id=summary_id,
-                    canonical_thread_id=thread_id,
-                    segment_index=seg_idx,
-                    title=thread_meta.get("title"),
-                    platform=thread_meta.get("platform"),
-                    message_count=len(seg_messages),
-                    segment_chars=seg_chars,
-                    ts_start=seg_ts_start,
-                    ts_end=seg_ts_end,
-                    summary=summary,
-                    key_topics=key_topics,
-                    summary_model=model,
-                    now=now_str,
-                    sensitivity=thread_meta.get("sensitivity", "public"),
-                )
+                new_segments.append({
+                    "summary_id": summary_id,
+                    "segment_index": seg_idx,
+                    "message_count": len(seg_messages),
+                    "segment_chars": seg_chars,
+                    "ts_start": seg_ts_start,
+                    "ts_end": seg_ts_end,
+                    "summary": summary,
+                    "key_topics": key_topics,
+                })
 
-                if embedder:
-                    try:
-                        emb = embedder(summary)
-                        db.insert_thread_summary_embedding(con, summary_id, emb)
-                    except Exception as e:
-                        print(f"  [summarize] Embedding failed for {summary_id}: {e}",
-                              file=sys.stderr)
+            if not new_segments and not force:
+                # Nothing needed regenerating (e.g. only stale extra segments
+                # from a shrunk thread remain — not cleaned up here).
+                continue
 
-                total_segments += 1
+            # Every segment this thread needed has now succeeded — commit the
+            # replacement as one savepoint so a write-time failure (e.g. a
+            # disk error) can't leave old summaries deleted with nothing new
+            # in their place.
+            con.execute("SAVEPOINT thread_summary_write")
+            try:
+                if force:
+                    db.delete_thread_summaries(con, thread_id)
+
+                for seg in new_segments:
+                    db.insert_thread_summary(
+                        con,
+                        summary_id=seg["summary_id"],
+                        canonical_thread_id=thread_id,
+                        segment_index=seg["segment_index"],
+                        title=thread_meta.get("title"),
+                        platform=thread_meta.get("platform"),
+                        message_count=seg["message_count"],
+                        segment_chars=seg["segment_chars"],
+                        ts_start=seg["ts_start"],
+                        ts_end=seg["ts_end"],
+                        summary=seg["summary"],
+                        key_topics=seg["key_topics"],
+                        summary_model=model,
+                        now=now_str,
+                        sensitivity=thread_meta.get("sensitivity", "public"),
+                    )
+
+                    if embedder:
+                        try:
+                            emb = embedder(seg["summary"])
+                            db.insert_thread_summary_embedding(con, seg["summary_id"], emb)
+                        except Exception as e:
+                            print(f"  [summarize] Embedding failed for {seg['summary_id']}: {e}",
+                                  file=sys.stderr)
+
+                    total_segments += 1
+            except Exception:
+                con.execute("ROLLBACK TO thread_summary_write")
+                raise
+            finally:
+                con.execute("RELEASE thread_summary_write")
 
             processed += 1
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Ensure tests import this checkout's src/, not whatever editable install
+happens to be active in the interpreter (e.g. a sibling git worktree)."""
+
+import sys
+from pathlib import Path
+
+_SRC = str(Path(__file__).resolve().parent.parent / "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)

--- a/tests/test_embeddings_openai.py
+++ b/tests/test_embeddings_openai.py
@@ -1,0 +1,116 @@
+"""Tests for the OpenAI embeddings backend's dimension handling.
+
+The 'openai' package is never imported here — the client is faked out via
+_get_client, so these tests run without the optional dependency installed
+and without any network access.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mychatarchive.backends.embeddings import openai as openai_backend
+from mychatarchive.config import get_embedding_dim
+
+
+@pytest.fixture(autouse=True)
+def config_path(tmp_path, monkeypatch):
+    """Point config at a tmp file per test and reset the cached client.
+
+    Tests must write config through this fixture's path, never by calling
+    mychatarchive.config.get_config_path() directly — that name was already
+    bound at import time in this module and monkeypatching the module
+    attribute afterward would not reroute it, which would otherwise touch
+    the real ~/.mychatarchive/config.json.
+    """
+    path = tmp_path / "config.json"
+    monkeypatch.setattr("mychatarchive.config.get_config_path", lambda: path)
+    monkeypatch.setattr(openai_backend, "_client", None)
+    return path
+
+
+def _write_config(path, embeddings_cfg: dict):
+    path.write_text(json.dumps({"embeddings": embeddings_cfg}))
+
+
+class _FakeItem:
+    def __init__(self, index, embedding):
+        self.index = index
+        self.embedding = embedding
+
+
+class _FakeResponse:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeEmbeddings:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        n = len(kwargs["input"])
+        dim = kwargs.get("dimensions", 4)  # arbitrary small stand-in when absent
+        return _FakeResponse([_FakeItem(i, [0.0] * dim) for i in range(n)])
+
+
+class _FakeClient:
+    def __init__(self):
+        self.embeddings = _FakeEmbeddings()
+
+
+# ── Bug 3, part 1: the dimensions param actually reaches the API call ─────────
+
+def test_embed_texts_passes_dimensions_for_matryoshka_models(config_path, monkeypatch):
+    _write_config(config_path, {
+        "backend": "openai", "model": "text-embedding-3-small", "dimension": 512,
+    })
+    fake_client = _FakeClient()
+    monkeypatch.setattr(openai_backend, "_get_client", lambda: fake_client)
+
+    openai_backend.embed_texts(["project-x sample text"])
+
+    assert len(fake_client.embeddings.calls) == 1
+    assert fake_client.embeddings.calls[0]["dimensions"] == 512
+
+
+def test_embed_texts_omits_dimensions_for_ada_002(config_path, monkeypatch):
+    """ada-002 doesn't accept the 'dimensions' param at all — sending it errors."""
+    _write_config(config_path, {
+        "backend": "openai", "model": "text-embedding-ada-002", "dimension": 1536,
+    })
+    fake_client = _FakeClient()
+    monkeypatch.setattr(openai_backend, "_get_client", lambda: fake_client)
+
+    openai_backend.embed_texts(["project-x sample text"])
+
+    assert "dimensions" not in fake_client.embeddings.calls[0]
+
+
+# ── Bug 3, part 2: default table dimension is backend-aware ───────────────────
+
+def test_default_dim_is_backend_aware(config_path):
+    _write_config(config_path, {"backend": "openai"})
+    assert get_embedding_dim() == 1536  # text-embedding-3-small's native dim
+
+    _write_config(config_path, {"backend": "openai", "model": "text-embedding-3-large"})
+    assert get_embedding_dim() == 3072
+
+    _write_config(config_path, {"backend": "openai", "model": "text-embedding-ada-002"})
+    assert get_embedding_dim() == 1536
+
+    # Conservative: local backend (and no backend at all) keep the original
+    # 384 default — existing local archives see no behavior change.
+    _write_config(config_path, {"backend": "local"})
+    assert get_embedding_dim() == 384
+
+    config_path.write_text(json.dumps({}))
+    assert get_embedding_dim() == 384
+
+    # Explicit config always wins over both the backend default and the
+    # model's native size.
+    _write_config(config_path, {"backend": "openai", "dimension": 256})
+    assert get_embedding_dim() == 256

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,0 +1,303 @@
+"""Tests for the summarizer pipeline (mychatarchive.summarizer).
+
+This is the only path that sends raw archive text to an external API, so
+every test here mocks the network layer (summarizer._call_api) and never
+makes a real HTTP call. Coverage:
+  - scope: sealed/private threads never reach the mocked API call by default;
+    include_private=True adds private but sealed still never leaves.
+  - Bug 1 regression: an API failure during --force leaves a thread's
+    pre-existing summaries (and their embeddings) untouched.
+  - Bug 2 regression: a thread with some segments already on disk only pays
+    for the missing/changed ones, and is not permanently skipped.
+  - happy path: segment_id format, sensitivity inheritance, multi-segment
+    threads.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mychatarchive import summarizer
+from mychatarchive.backends.storage import sqlite as store
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config(tmp_path, monkeypatch):
+    """Point config at an empty tmp file so a real dev config (e.g. a
+    configured openai backend or custom dimension) can never leak into these
+    tests, and so _resolve_api_key never touches real env/config."""
+    import mychatarchive.config as config_mod
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(config_mod, "get_config_path", lambda: config_path)
+    for env in ("OPENROUTER_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"):
+        monkeypatch.delenv(env, raising=False)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "archive.sqlite"
+    con = store.get_connection(path)
+    store.ensure_schema(con)
+    con.close()
+    return path
+
+
+def _msg(con, mid, thread, text, ts, title, platform="chatgpt"):
+    store.insert_message(con, mid, thread, platform, "main", ts, "user", text, title, "src")
+
+
+class FakeAPI:
+    """Stand-in for summarizer._call_api. Records every prompt it receives
+    and can be told to fail on a specific (1-based) call."""
+
+    def __init__(self, fail_at: int | None = None, fail_error: Exception | None = None):
+        self.calls: list[str] = []
+        self.fail_at = fail_at
+        self.fail_error = fail_error or RuntimeError("simulated API failure")
+
+    def __call__(self, prompt: str, api_key: str, base_url: str, model: str) -> dict:
+        self.calls.append(prompt)
+        if self.fail_at is not None and len(self.calls) == self.fail_at:
+            raise self.fail_error
+        n = len(self.calls)
+        return {
+            "choices": [
+                {"message": {"content": json.dumps({
+                    "summary": f"generated summary #{n}",
+                    "key_topics": [f"topic-{n}"],
+                })}}
+            ]
+        }
+
+
+def _run(db_path, monkeypatch, fake_api, **kwargs):
+    monkeypatch.setattr(summarizer, "_call_api", fake_api)
+    kwargs.setdefault("api_key", "sk-test-not-real")
+    kwargs.setdefault("embed_summaries", False)
+    return summarizer.run(db_path, **kwargs)
+
+
+# ── Scope: the egress control this whole module exists to enforce ─────────────
+
+def test_default_scope_excludes_private_and_sealed(db_path, monkeypatch):
+    con = store.get_connection(db_path)
+    _msg(con, "m-pub", "pub", "project-x public MARKER-PUB", "2024-01-01T00:00:00", "Pub thread")
+    _msg(con, "m-priv", "priv", "project-x private MARKER-PRIV", "2024-01-01T00:00:00", "Priv thread")
+    _msg(con, "m-seal", "seal", "project-x sealed MARKER-SEAL", "2024-01-01T00:00:00", "Seal thread")
+    con.commit()
+    store.set_thread_sensitivity(con, ["priv"], "private")
+    store.set_thread_sensitivity(con, ["seal"], "sealed")
+    con.close()
+
+    fake = FakeAPI()
+    result = _run(db_path, monkeypatch, fake)
+
+    assert result["processed"] == 1
+    assert len(fake.calls) == 1
+    assert "MARKER-PUB" in fake.calls[0]
+    assert not any("MARKER-PRIV" in c or "MARKER-SEAL" in c for c in fake.calls)
+    assert not any("Priv thread" in c or "Seal thread" in c for c in fake.calls)
+
+
+def test_include_private_adds_private_but_never_sealed(db_path, monkeypatch):
+    con = store.get_connection(db_path)
+    _msg(con, "m-pub", "pub", "project-x public MARKER-PUB", "2024-01-01T00:00:00", "Pub thread")
+    _msg(con, "m-priv", "priv", "project-x private MARKER-PRIV", "2024-01-01T00:00:00", "Priv thread")
+    _msg(con, "m-seal", "seal", "project-x sealed MARKER-SEAL", "2024-01-01T00:00:00", "Seal thread")
+    con.commit()
+    store.set_thread_sensitivity(con, ["priv"], "private")
+    store.set_thread_sensitivity(con, ["seal"], "sealed")
+    con.close()
+
+    # First pass: public only (as above) so the public thread is already
+    # complete and won't be re-summarized on the second pass below.
+    _run(db_path, monkeypatch, FakeAPI())
+
+    fake2 = FakeAPI()
+    result = _run(db_path, monkeypatch, fake2, include_private=True)
+
+    assert result["processed"] == 1  # only "priv" was left incomplete in scope
+    assert len(fake2.calls) == 1
+    assert "MARKER-PRIV" in fake2.calls[0]
+    assert not any("MARKER-SEAL" in c for c in fake2.calls)
+
+
+# ── Bug 1: --force must not destroy summaries before the replacement lands ────
+
+def test_force_failure_preserves_existing_summaries_and_embeddings(db_path, monkeypatch):
+    con = store.get_connection(db_path)
+    _msg(con, "m1", "t1", "project-x original content", "2024-01-01T00:00:00", "Original title")
+    con.commit()
+    con.close()
+
+    def fake_embed(text):
+        return [0.1] * 384
+
+    import mychatarchive.embeddings as embeddings_mod
+    monkeypatch.setattr(embeddings_mod, "embed_single", fake_embed)
+
+    # Successful initial run, with embeddings this time, to establish a
+    # baseline that --force must not be able to destroy on failure.
+    ok = _run(db_path, monkeypatch, FakeAPI(), embed_summaries=True)
+    assert ok["processed"] == 1
+
+    con = store.get_connection(db_path)
+    before = store.get_thread_summaries(con, "t1")
+    assert len(before) == 1
+    assert before[0][8] == "generated summary #1"
+    vec_before = con.execute(
+        "SELECT count(*) FROM vec_thread_summaries WHERE summary_id = 't1::0000'"
+    ).fetchone()[0]
+    assert vec_before == 1
+    con.close()
+
+    # Now --force with an API that fails on every call (e.g. an expired key).
+    failing = FakeAPI(fail_at=1)
+    result = _run(db_path, monkeypatch, failing, force=True, embed_summaries=True)
+    assert result["processed"] == 0
+    assert result["errors"] == 1
+
+    con = store.get_connection(db_path)
+    after = store.get_thread_summaries(con, "t1")
+    assert len(after) == 1
+    assert after[0][8] == "generated summary #1"  # untouched, not wiped
+    vec_after = con.execute(
+        "SELECT count(*) FROM vec_thread_summaries WHERE summary_id = 't1::0000'"
+    ).fetchone()[0]
+    assert vec_after == 1  # embedding survived too
+    con.close()
+
+
+# ── Bug 2: partial threads must be resumable, not permanently skipped ─────────
+
+def test_resume_only_calls_api_for_segments_that_changed(db_path, monkeypatch):
+    """Seed segments 0 and 1 directly (as if two earlier runs had completed
+    them) with a thread now long enough for 3 segments. A run should only
+    call the API for segment 2, and must not touch 0/1's stored summaries."""
+    con = store.get_connection(db_path)
+    now = "2024-01-01T00:00:00"
+    # 5 messages, messages_per_segment=2 -> segments of size [2, 2, 1]
+    for i in range(5):
+        _msg(con, f"m{i}", "t1", f"project-x message {i}", now, "Growing thread")
+    con.commit()
+
+    store.insert_thread_summary(
+        con, "t1::0000", "t1", 0, "Growing thread", "chatgpt", 2, 20, now, now,
+        "already summarized segment 0", ["old-topic"], "prior-model", now,
+    )
+    store.insert_thread_summary(
+        con, "t1::0001", "t1", 1, "Growing thread", "chatgpt", 2, 20, now, now,
+        "already summarized segment 1", ["old-topic"], "prior-model", now,
+    )
+    con.commit()
+    con.close()
+
+    fake = FakeAPI()
+    result = _run(db_path, monkeypatch, fake, messages_per_segment=2)
+
+    assert len(fake.calls) == 1  # only segment 2 needed an API call
+    assert result["processed"] == 1
+
+    con = store.get_connection(db_path)
+    segs = store.get_thread_summaries(con, "t1")
+    con.close()
+    assert len(segs) == 3
+    by_index = {r[2]: r for r in segs}
+    assert by_index[0][8] == "already summarized segment 0"  # untouched
+    assert by_index[1][8] == "already summarized segment 1"  # untouched
+    assert by_index[2][8] == "generated summary #1"  # newly generated
+
+
+def test_thread_not_permanently_stuck_after_a_failed_run(db_path, monkeypatch):
+    """Old bug: once any summary row existed for a thread, has_thread_summary()
+    marked it complete forever. Verify a thread that fails on its first
+    attempt is picked up again (and fully summarized) on the next run."""
+    con = store.get_connection(db_path)
+    _msg(con, "m1", "t1", "project-x retry-me content", "2024-01-01T00:00:00", "Retry thread")
+    con.commit()
+    con.close()
+
+    failing = FakeAPI(fail_at=1)
+    r1 = _run(db_path, monkeypatch, failing)
+    assert r1["processed"] == 0
+    assert r1["errors"] == 1
+
+    con = store.get_connection(db_path)
+    assert store.get_thread_summaries(con, "t1") == []
+    con.close()
+
+    succeeding = FakeAPI()
+    r2 = _run(db_path, monkeypatch, succeeding)
+    assert r2["processed"] == 1
+    assert len(succeeding.calls) == 1
+
+    con = store.get_connection(db_path)
+    segs = store.get_thread_summaries(con, "t1")
+    con.close()
+    assert len(segs) == 1
+    assert segs[0][8] == "generated summary #1"
+
+
+def test_growing_thread_only_pays_for_the_new_segment(db_path, monkeypatch):
+    """End-to-end (not pre-seeded): a thread fully summarized in one run,
+    then grown, should only re-call the API for the new tail segment."""
+    con = store.get_connection(db_path)
+    now = "2024-01-01T00:00:00"
+    _msg(con, "m0", "t1", "project-x first message", now, "Growing thread")
+    _msg(con, "m1", "t1", "project-x second message", now, "Growing thread")
+    con.commit()
+    con.close()
+
+    first = FakeAPI()
+    r1 = _run(db_path, monkeypatch, first, messages_per_segment=2)
+    assert r1["processed"] == 1
+    assert len(first.calls) == 1  # one segment, 2/2 messages
+
+    con = store.get_connection(db_path)
+    _msg(con, "m2", "t1", "project-x third message", now, "Growing thread")
+    con.commit()
+    con.close()
+
+    second = FakeAPI()
+    r2 = _run(db_path, monkeypatch, second, messages_per_segment=2)
+    assert r2["processed"] == 1
+    assert len(second.calls) == 1  # only the new segment, not a re-summarize of segment 0
+
+    con = store.get_connection(db_path)
+    segs = store.get_thread_summaries(con, "t1")
+    con.close()
+    by_index = {r[2]: r for r in segs}
+    assert len(segs) == 2
+    assert by_index[0][8] == "generated summary #1"  # from run 1, untouched by run 2
+    assert by_index[1][8] == "generated summary #1"  # run 2's own first (and only) call
+
+
+# ── Happy path ──────────────────────────────────────────────────────────────
+
+def test_happy_path_segment_ids_and_sensitivity(db_path, monkeypatch):
+    con = store.get_connection(db_path)
+    now = "2024-01-01T00:00:00"
+    for i in range(3):
+        _msg(con, f"m{i}", "t1", f"project-x message {i}", now, "Multi-segment thread")
+    con.commit()
+    store.set_thread_sensitivity(con, ["t1"], "private")
+    con.close()
+
+    fake = FakeAPI()
+    result = _run(db_path, monkeypatch, fake, messages_per_segment=1, include_private=True)
+
+    assert result["processed"] == 1
+    assert result["segments"] == 3
+    assert len(fake.calls) == 3
+
+    con = store.get_connection(db_path)
+    segs = store.get_thread_summaries(con, "t1", scope=store.SENSITIVITY_LEVELS)
+    sens = con.execute(
+        "SELECT sensitivity FROM thread_summaries WHERE canonical_thread_id='t1'"
+    ).fetchall()
+    con.close()
+    assert [r[0] for r in segs] == ["t1::0000", "t1::0001", "t1::0002"]
+    assert all(r[0] == "private" for r in sens)


### PR DESCRIPTION
Four findings from the post-v0.4.0 review, all on the summarize/embed path. `summarize` is the only command that sends archive content off-machine, and until now it had zero tests.

## 1. `--force` destroyed summaries before their replacements existed

For each thread, `delete_thread_summaries()` ran *before* the API call. When the call failed, the exception was caught, the loop moved on, and the final commit persisted every uncompensated deletion. `summarize --force` with an expired API key therefore wiped the entire summary layer — real API spend — and produced zero replacements.

**Fix:** generate a thread's segments into memory first; touch the database only once every needed segment has succeeded, inside a `SAVEPOINT` that rolls back on write failure. An API failure now leaves the thread's existing summaries and their vector rows completely untouched.

## 2. Partially-summarized threads were skipped forever

A thread whose API call failed on segment 2 of 3 kept its first two segments; on the next run `has_thread_summary()` saw rows and filtered the thread out permanently. The remainder was unreachable short of `--force` over the whole archive.

**Fix:** completeness is now measured — a thread is done only when its stored segment count matches `ceil(message_count / messages_per_segment)`. Segments already on disk with an unchanged `message_count` are reused rather than re-paid for, so a thread that merely grew only pays for its new tail.

**Trade-off, stated plainly:** per-thread atomicity means a failed attempt discards that attempt's successful segments too, so a failed run saves no partial progress. The thread is never permanently skipped, and segments from an earlier *completed* run are always reused. Two edge cases remain unhandled: a shrunk thread can leave stale extra segments, and a `messages_per_segment` change that coincidentally preserves the segment count needs `--force` to detect.

## 3. OpenAI embeddings ignored the configured dimension

`embed_texts()` never sent the `dimensions` parameter, so the API returned each model's native size regardless of what `vec_chunks` was built for. A fresh archive with `{"embeddings": {"backend": "openai"}}` and no explicit dimension built a float[384] table (384 is the *local* model's dim) and then failed on the first insert — after paying for the batch.

**Fix:** send `dimensions` for the `-3` models that support Matryoshka shortening (omitted for `ada-002`, which errors if it is sent), and make the default dimension backend-aware so an OpenAI-backend archive defaults to its model's native size instead of the local model's.

**Disclosed behavior change:** an archive built with `backend=local` and later switched to `backend=openai` with no explicit dimension now raises the existing dimension-mismatch guard loudly instead of silently writing mismatched vectors. Explicit `"dimension"` config always wins, so pinned setups are unaffected.

## 4. Zero summarizer tests

10 new tests, network fully mocked (no API call is ever made). They cover the sensitivity guarantee that matters most: a sealed thread is never passed to the API by default **or** with `--include-private`, and a private thread only with the explicit opt-in — plus the fixes above and the happy path.

## Test-infrastructure fix included

`tests/conftest.py` now puts the checkout's `src/` at the front of `sys.path`. Without it, an editable install pointing anywhere else (a sibling git worktree, another clone) silently runs the suite against *that* code — which happened during this work and can make a green run meaningless.

## Verification

145 tests pass (10 new). Every fix was reverted in isolation to confirm its tests fail without it, verified independently of the agent that wrote them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)