### PR TITLE
Fix classify coverage gap, init config destruction, mcp dependency range, and plugin private-content blackout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,5 +38,8 @@ planning, ranking, and final review.
   retrieval paths must enforce scope; sealed must remain unreachable via MCP.
 - CLI handlers: heavy imports function-local, errors to stderr + exit 1,
   results to stdout, `_add_db_arg` on every db-touching subparser leaf.
-- `_cmd_init` rebuilds config.json from a whitelist dict — new top-level
-  config keys must be added there or `init` silently deletes them.
+- `_cmd_init` starts from the existing config.json (`load_config()`) and only
+  `setdefault`s the keys it manages (storage, embeddings, transport,
+  drop_folder, auto_sources, sources) — it never rebuilds the dict from a
+  whitelist, so unrelated top-level keys (e.g. `summarize`) always survive
+  a re-run.

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -13,6 +13,13 @@ Config via $HERMES_HOME/mychatarchive.json (profile-scoped):
   db_path:         path to the MCA SQLite database (default: ~/.mychatarchive/archive.db)
   recall_mode:     hybrid | context | tools (default: hybrid)
   prefetch_limit:  max chunks injected per turn (default: 5)
+  include_private: also retrieve content classified private (default: false)
+
+Sensitivity scope: this plugin calls mychatarchive.db directly, bypassing
+the MCP server, so it enforces the same fail-closed scope itself. Default
+scope is public-only; include_private widens it to public+private. Sealed
+is never reachable here, by construction (see _PLUGIN_ALLOWED_LEVELS below)
+-- mirrors src/mychatarchive/mcp/server.py's _scope()/_MCP_ALLOWED_LEVELS.
 """
 
 from __future__ import annotations
@@ -163,6 +170,27 @@ MCA_PROVENANCE_SCHEMA = {
 
 
 # ---------------------------------------------------------------------------
+# Sensitivity scope
+# ---------------------------------------------------------------------------
+
+# This plugin calls mychatarchive.db directly (bypassing the MCP server), so
+# it must enforce the same fail-closed sensitivity scope itself. Sealed is
+# never included here at all -- no config value or code path can widen scope
+# to contain it -- mirroring mcp/server.py's _MCP_ALLOWED_LEVELS allowlist.
+_PLUGIN_ALLOWED_LEVELS = ("public", "private")
+
+
+def _coerce_bool(value: Any) -> bool:
+    """Lenient bool coercion for config values that may arrive as JSON bool,
+    a string ("true"/"false"/"1"/"0"), or be absent entirely."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes", "on")
+    return bool(value)
+
+
+# ---------------------------------------------------------------------------
 # Config helpers
 # ---------------------------------------------------------------------------
 
@@ -293,6 +321,7 @@ class MyChatArchiveProvider(MemoryProvider):
         self._hermes_home: str = ""
         self._recall_mode: str = "hybrid"
         self._prefetch_limit: int = 5
+        self._include_private: bool = False
         self._sync_thread: Optional[threading.Thread] = None
 
     @property
@@ -333,6 +362,15 @@ class MyChatArchiveProvider(MemoryProvider):
                 "key": "prefetch_limit",
                 "description": "Max chunks auto-injected per turn",
                 "default": "5",
+            },
+            {
+                "key": "include_private",
+                "description": (
+                    "Also retrieve content classified private. Sealed content is "
+                    "never retrieved by this plugin, regardless of this setting."
+                ),
+                "default": "false",
+                "choices": ["true", "false"],
             },
         ]
 
@@ -468,6 +506,11 @@ class MyChatArchiveProvider(MemoryProvider):
             self._prefetch_limit = int(self._config.get("prefetch_limit", 5))
         except (ValueError, TypeError):
             self._prefetch_limit = 5
+        # Fail closed to public-only, matching the MCP server's default --
+        # a user must explicitly opt in to widen their own agent's access to
+        # content they've classified private. Sealed is never reachable here
+        # regardless of this setting (see _scope() / _PLUGIN_ALLOWED_LEVELS).
+        self._include_private = _coerce_bool(self._config.get("include_private", False))
 
         db_path = _resolve_db_path(self._config)
         if not db_path.exists():
@@ -567,13 +610,14 @@ class MyChatArchiveProvider(MemoryProvider):
             embedding = self._embeddings.embed_single(query)
             results = self._db.search_chunks(
                 self._con, embedding, limit=self._prefetch_limit,
+                scope=self._scope(),
             )
             if not results:
                 return ""
 
             lines: List[str] = []
             for chunk_id, distance in results:
-                row = self._db.get_chunk_by_id(self._con, chunk_id)
+                row = self._db.get_chunk_by_id(self._con, chunk_id, scope=self._scope())
                 if not row:
                     continue
                 text, thread_id, ts_start, ts_end, meta_json = row
@@ -669,6 +713,39 @@ class MyChatArchiveProvider(MemoryProvider):
         self._db = None
         self._embeddings = None
 
+    # -- Sensitivity scope -----------------------------------------------
+
+    def _scope(self) -> tuple:
+        """Resolve the plugin's current sensitivity scope.
+
+        Mirrors mcp/server.py's _scope(): defaults to public-only, widens to
+        public+private when include_private is set, and filters through the
+        _PLUGIN_ALLOWED_LEVELS allowlist so sealed can never appear here even
+        if this function is edited carelessly in the future.
+        """
+        scope = ("public", "private") if self._include_private else ("public",)
+        return tuple(s for s in scope if s in _PLUGIN_ALLOWED_LEVELS)
+
+    def _restricted_message(self, kind: str, item_id: str, lookup) -> str:
+        """Build an honest "not found" message for a direct-ID provenance lookup.
+
+        A row that's absent and a row that exists but is outside the current
+        scope both come back as None from `lookup`, and it used to be
+        impossible to tell them apart -- mca_provenance reported "not found"
+        either way, which tells the user their data was lost when it was
+        merely restricted. If include_private is off, re-check against
+        public+private (never sealed -- that scope stays unreachable
+        regardless) to see whether the gap is explained by private access
+        being off; if so, say so instead of claiming the data doesn't exist.
+        """
+        if not self._include_private:
+            if lookup(self._con, item_id, scope=("public", "private")) is not None:
+                return (
+                    f"{kind} {item_id} exists but is classified private. "
+                    f"Enable include_private in the mychatarchive plugin config to access it."
+                )
+        return f"{kind} not found: {item_id}"
+
     # -- Tool handlers -------------------------------------------------------
 
     def _handle_search(self, args: dict) -> str:
@@ -696,13 +773,13 @@ class MyChatArchiveProvider(MemoryProvider):
             hits = self._db.search_chunks(
                 self._con, embedding, limit=limit,
                 platform=platform, cutoff_iso=cutoff,
-                group_thread_ids=group_ids,
+                group_thread_ids=group_ids, scope=self._scope(),
             )
             for chunk_id, distance in hits:
                 if chunk_id in seen_ids:
                     continue
                 seen_ids.add(chunk_id)
-                row = self._db.get_chunk_by_id(self._con, chunk_id)
+                row = self._db.get_chunk_by_id(self._con, chunk_id, scope=self._scope())
                 if not row:
                     continue
                 text, thread_id, ts_start, ts_end, meta_json = row
@@ -722,7 +799,7 @@ class MyChatArchiveProvider(MemoryProvider):
             fts_hits = self._db.fts_search(
                 self._con, query, limit=limit,
                 platform=platform, cutoff_iso=cutoff,
-                group_thread_ids=group_ids,
+                group_thread_ids=group_ids, scope=self._scope(),
             )
             for row in fts_hits:
                 msg_id, text, thread_id, ts, role, title = (
@@ -761,10 +838,10 @@ class MyChatArchiveProvider(MemoryProvider):
         messages: List[dict] = []
         chunk_hits = self._db.search_chunks(
             self._con, embedding, limit=limit,
-            platform=platform, group_thread_ids=group_ids,
+            platform=platform, group_thread_ids=group_ids, scope=self._scope(),
         )
         for chunk_id, distance in chunk_hits:
-            row = self._db.get_chunk_by_id(self._con, chunk_id)
+            row = self._db.get_chunk_by_id(self._con, chunk_id, scope=self._scope())
             if not row:
                 continue
             text, thread_id, ts_start, ts_end, meta_json = row
@@ -783,10 +860,10 @@ class MyChatArchiveProvider(MemoryProvider):
         # search_thread_summaries does not accept those params)
         summaries: List[dict] = []
         summary_hits = self._db.search_thread_summaries(
-            self._con, embedding, limit=limit * 3,
+            self._con, embedding, limit=limit * 3, scope=self._scope(),
         )
         for summary_id, distance in summary_hits:
-            row = self._db.get_summary_by_id(self._con, summary_id)
+            row = self._db.get_summary_by_id(self._con, summary_id, scope=self._scope())
             if not row:
                 continue
             # 10-col: summary_id, thread_id, segment_index, title,
@@ -818,9 +895,11 @@ class MyChatArchiveProvider(MemoryProvider):
 
         # Layer 3: captured thoughts
         thoughts: List[dict] = []
-        thought_hits = self._db.search_thoughts(self._con, embedding, limit=limit)
+        thought_hits = self._db.search_thoughts(
+            self._con, embedding, limit=limit, scope=self._scope(),
+        )
         for thought_id, distance in thought_hits:
-            row = self._db.get_thought_by_id(self._con, thought_id)
+            row = self._db.get_thought_by_id(self._con, thought_id, scope=self._scope())
             if not row:
                 continue
             text, created_at, meta_json = row
@@ -879,9 +958,11 @@ class MyChatArchiveProvider(MemoryProvider):
             return tool_error("Provide only one of chunk_id or thought_id, not both.")
 
         if chunk_id:
-            row = self._db.get_chunk_by_id(self._con, chunk_id)
+            row = self._db.get_chunk_by_id(self._con, chunk_id, scope=self._scope())
             if not row:
-                return tool_error(f"Chunk not found: {chunk_id}")
+                return tool_error(
+                    self._restricted_message("Chunk", chunk_id, self._db.get_chunk_by_id)
+                )
             text, thread_id, ts_start, ts_end, meta_json = row
             meta = _parse_meta(meta_json)
 
@@ -889,7 +970,7 @@ class MyChatArchiveProvider(MemoryProvider):
             thread_title = meta.get("title", "")
             thread_summary = ""
             thread_platform = meta.get("platform", "")
-            summary_row = self._db.get_thread_summary(self._con, thread_id)
+            summary_row = self._db.get_thread_summary(self._con, thread_id, scope=self._scope())
             if summary_row:
                 thread_title = thread_title or summary_row[3] or ""
                 thread_platform = thread_platform or summary_row[4] or ""
@@ -909,9 +990,11 @@ class MyChatArchiveProvider(MemoryProvider):
             })
 
         # thought_id path
-        row = self._db.get_thought_by_id(self._con, thought_id)
+        row = self._db.get_thought_by_id(self._con, thought_id, scope=self._scope())
         if not row:
-            return tool_error(f"Thought not found: {thought_id}")
+            return tool_error(
+                self._restricted_message("Thought", thought_id, self._db.get_thought_by_id)
+            )
         text, created_at, meta_json = row
         meta = _parse_meta(meta_json)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,15 @@ classifiers = [
 # [local] extra; hosted embeddings use the [openai] extra.
 dependencies = [
     "sqlite-vec>=0.1.1",
-    "mcp[cli]>=1.0.0",
+    # Floor is 1.10.0, not a round number: FastMCP (mcp.server.fastmcp) only
+    # exists from 1.2.0 onward, and src/mychatarchive/mcp/server.py also sets
+    # mcp.settings.transport_security.enable_dns_rebinding_protection, which
+    # requires the TransportSecuritySettings support added in 1.10.0 (that's
+    # the binding constraint -- an installed 1.2.x-1.9.x satisfies FastMCP
+    # but AttributeErrors on transport_security). A resolver that keeps an
+    # already-installed pre-1.10 mcp otherwise satisfies a looser floor and
+    # dies at runtime instead of at install time.
+    "mcp[cli]>=1.10.0",
     "tqdm>=4.66.0",
     "ijson>=3.2.0",
     "rich>=13.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,17 @@ dependencies = [
     # but AttributeErrors on transport_security). A resolver that keeps an
     # already-installed pre-1.10 mcp otherwise satisfies a looser floor and
     # dies at runtime instead of at install time.
-    "mcp[cli]>=1.10.0",
+    #
+    # Capped below 2.0.0: mcp 2.0.0 is a separate, deliberately breaking
+    # major version (the v1.x line continued in parallel through 1.29.0,
+    # released the same day as 2.0.0) that removed mcp.server.fastmcp
+    # entirely -- FastMCP now lives at mcp.server.mcpserver, and its
+    # transport params (host/port/transport_security/...) moved from the
+    # settings object onto run()/sse_app()/streamable_http_app() call
+    # arguments. server.py uses the pre-2.0 shape (mcp.server.fastmcp
+    # import, mcp.settings.port = port, mcp.sse_app() with no args), so
+    # >=2.0.0 breaks at import time, not just at the TLS code path.
+    "mcp[cli]>=1.10.0,<2.0.0",
     "tqdm>=4.66.0",
     "ijson>=3.2.0",
     "rich>=13.0.0",

--- a/src/mychatarchive/backends/storage/__init__.py
+++ b/src/mychatarchive/backends/storage/__init__.py
@@ -88,6 +88,13 @@ class StorageBackend(Protocol):
         group_thread_ids: set[str] | None = None,
         *, scope: tuple = DEFAULT_SCOPE,
     ) -> list: ...
+    def fts_search_thread_ids(
+        self, con, query: str,
+        platform: str | list[str] | None = None,
+        cutoff_iso: str | None = None,
+        group_thread_ids: set[str] | None = None,
+        *, scope: tuple = DEFAULT_SCOPE,
+    ) -> list[str]: ...
     def search_thread_summaries(
         self, con, embedding: list[float], limit: int = 10,
         *, scope: tuple = DEFAULT_SCOPE,

--- a/src/mychatarchive/backends/storage/sqlite.py
+++ b/src/mychatarchive/backends/storage/sqlite.py
@@ -802,6 +802,50 @@ def fts_search(
     return con.execute(sql, params).fetchall()
 
 
+def fts_search_thread_ids(
+    con: sqlite3.Connection,
+    query: str,
+    platform: str | list[str] | None = None,
+    cutoff_iso: str | None = None,
+    group_thread_ids: set[str] | None = None,
+    *,
+    scope: tuple = _DEFAULT_SCOPE,
+) -> list[str]:
+    """Distinct thread ids with at least one FTS match, uncapped.
+
+    Bulk classification needs every matching thread, not just the top-N
+    matching messages — thread count is far smaller than message count, so
+    selecting distinct thread ids with no row LIMIT is cheap and bounded
+    (bounded by thread count, not match count).
+    """
+    if group_thread_ids is not None and not group_thread_ids:
+        return []
+    scope_sql, scope_params = _scope_sql(scope, "m.sensitivity")
+    match = _build_fts_match(query)
+    if not match:
+        return []
+    sql = f"""
+        SELECT DISTINCT m.canonical_thread_id
+        FROM messages_fts f
+        JOIN messages m ON m.rowid = f.rowid
+        WHERE messages_fts MATCH ? AND {scope_sql}
+    """
+    params: list = [match, *scope_params]
+    if platform:
+        platforms = [platform] if isinstance(platform, str) else platform
+        placeholders = ",".join("?" * len(platforms))
+        sql += f" AND m.platform IN ({placeholders})"
+        params.extend(platforms)
+    if cutoff_iso:
+        sql += " AND m.ts >= ?"
+        params.append(cutoff_iso)
+    if group_thread_ids:
+        placeholders = ",".join("?" * len(group_thread_ids))
+        sql += f" AND m.canonical_thread_id IN ({placeholders})"
+        params.extend(group_thread_ids)
+    return [r[0] for r in con.execute(sql, params).fetchall()]
+
+
 def get_recent_chunks(
     con: sqlite3.Connection,
     cutoff_iso: str,

--- a/src/mychatarchive/cli.py
+++ b/src/mychatarchive/cli.py
@@ -417,15 +417,19 @@ def _cmd_init():
         _DEFAULT_CHUNK_SIZE, _DEFAULT_CHUNK_OVERLAP,
     )
 
-    existing = load_config()
-    cfg = {
-        "storage": existing.get("storage", {}),
-        "embeddings": existing.get("embeddings", {}),
-        "transport": existing.get("transport", {}),
-        "drop_folder": existing.get("drop_folder", _DEFAULT_DROP_FOLDER),
-        "auto_sources": existing.get("auto_sources", dict(_AUTO_SOURCE_DEFAULTS)),
-        "sources": existing.get("sources", {}),
-    }
+    # Start from the existing config and only fill in the keys init actually
+    # manages (storage/embeddings/transport/drop_folder/auto_sources/sources)
+    # instead of rebuilding from a hardcoded whitelist. Any other top-level
+    # key (e.g. the `summarize` block written by `mychatarchive summarize`)
+    # survives untouched, so re-running init can never silently delete a
+    # config section it doesn't know about.
+    cfg = load_config()
+    cfg.setdefault("storage", {})
+    cfg.setdefault("embeddings", {})
+    cfg.setdefault("transport", {})
+    cfg.setdefault("drop_folder", _DEFAULT_DROP_FOLDER)
+    cfg.setdefault("auto_sources", dict(_AUTO_SOURCE_DEFAULTS))
+    cfg.setdefault("sources", {})
 
     print("MyChatArchive Setup")
     print("=" * 50)

--- a/src/mychatarchive/cli.py
+++ b/src/mychatarchive/cli.py
@@ -1114,10 +1114,12 @@ def _cmd_classify(args, db_path: Path):
     # reading it, so it must never fire by accident.
     if args.query:
         # Classification tooling must see everything, or already-classified
-        # content could never be re-classified.
-        matches = db.fts_search(con, args.query, limit=10000,
-                                scope=db.SENSITIVITY_LEVELS)
-        thread_ids = sorted({row[2] for row in matches})
+        # content could never be re-classified. Uses the uncapped
+        # thread-id-only lookup (not fts_search's row-limited message search)
+        # so a keyword matching more than any row cap still classifies every
+        # matching thread, not just the top-N matching messages.
+        thread_ids = sorted(db.fts_search_thread_ids(con, args.query,
+                                                       scope=db.SENSITIVITY_LEVELS))
         selector_desc = f"threads with keyword match for {args.query!r}"
     else:
         import datetime

--- a/src/mychatarchive/db.py
+++ b/src/mychatarchive/db.py
@@ -137,6 +137,27 @@ def fts_search(
     )
 
 
+def fts_search_thread_ids(
+    con,
+    query: str,
+    platform: str | list[str] | None = None,
+    cutoff_iso: str | None = None,
+    group_thread_ids: set | None = None,
+    *,
+    scope: tuple = DEFAULT_SCOPE,
+) -> list[str]:
+    """Distinct thread ids with at least one FTS match, uncapped.
+
+    Unlike fts_search (which caps rows via `limit` for interactive display),
+    this has no row cap — it's for callers (bulk classification) that need
+    every matching thread, not just the top-N matching messages.
+    """
+    return _b().fts_search_thread_ids(
+        con, query, platform=platform, cutoff_iso=cutoff_iso,
+        group_thread_ids=group_thread_ids, scope=scope,
+    )
+
+
 def get_recent_chunks(
     con,
     cutoff_iso: str,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,3 +162,75 @@ def test_sqlite_export_refuses_sealed_without_flag(tmp_path, monkeypatch, capsys
          monkeypatch)
     assert "copied" in capsys.readouterr().out
     assert out_file.exists()
+
+
+def _seed_many_matching_threads(tmp_path, n):
+    """n threads, each with one message matching 'WIDGET', plus one distractor
+    thread that does not match. Synthetic stand-in for "more matching threads
+    than any row cap" -- see test_fts_search_thread_ids_covers_every_matching_
+    thread_beyond_any_row_cap in test_sensitivity.py for the storage-level
+    version of this regression at the point where it actually bites (a
+    message-row LIMIT, not a thread count)."""
+    from mychatarchive.backends.storage import sqlite as store
+
+    db_file = tmp_path / "archive.db"
+    con = store.get_connection(db_file)
+    store.ensure_schema(con)
+    for i in range(n):
+        store.insert_message(con, f"m-{i}", f"thread-{i}", "chatgpt", "main",
+                             "2024-01-01T00:00:00", "user",
+                             "WIDGET rollout notes", f"Title {i}", "s")
+    store.insert_message(con, "m-distractor", "t-other", "chatgpt", "main",
+                         "2024-01-01T00:00:00", "user",
+                         "unrelated content", "Other", "s")
+    con.commit()
+    con.close()
+    return db_file
+
+
+def test_classify_query_covers_every_matching_thread(tmp_path, monkeypatch, capsys):
+    # Regression: --query used to derive thread_ids from a row-limited
+    # fts_search (limit=10000), so threads whose match fell outside that cap
+    # were never classified. Every matching thread must be covered.
+    n = 15
+    db_file = _seed_many_matching_threads(tmp_path, n)
+
+    _run(["classify", "--query", "WIDGET", "--level", "private", "--confirm",
+          "--db", str(db_file)], monkeypatch)
+    out = capsys.readouterr().out
+    assert f"Applied 'private' to {n:,} threads" in out
+
+    con = sqlite3.connect(db_file)
+    levels = dict(con.execute("SELECT canonical_thread_id, sensitivity FROM messages"))
+    con.close()
+    assert all(levels[f"thread-{i}"] == "private" for i in range(n))
+    assert levels["t-other"] == "public"  # non-matching thread untouched
+
+
+def test_classify_query_uses_uncapped_thread_lookup(tmp_path, monkeypatch, capsys):
+    # Wiring check: --query selection must go through the dedicated uncapped
+    # fts_search_thread_ids, not the row-limited fts_search used for
+    # interactive message search/display.
+    db_file = _seed_many_matching_threads(tmp_path, 3)
+
+    from mychatarchive import db as db_module
+    calls = {"fts_search": 0, "fts_search_thread_ids": 0}
+    orig_fts_search = db_module.fts_search
+    orig_thread_ids = db_module.fts_search_thread_ids
+
+    def spy_fts_search(*a, **k):
+        calls["fts_search"] += 1
+        return orig_fts_search(*a, **k)
+
+    def spy_thread_ids(*a, **k):
+        calls["fts_search_thread_ids"] += 1
+        return orig_thread_ids(*a, **k)
+
+    monkeypatch.setattr(db_module, "fts_search", spy_fts_search)
+    monkeypatch.setattr(db_module, "fts_search_thread_ids", spy_thread_ids)
+
+    _run(["classify", "--query", "WIDGET", "--level", "private", "--confirm",
+          "--db", str(db_file)], monkeypatch)
+
+    assert calls["fts_search_thread_ids"] == 1
+    assert calls["fts_search"] == 0

--- a/tests/test_init_config.py
+++ b/tests/test_init_config.py
@@ -1,0 +1,76 @@
+"""Regression tests for `mychatarchive init` config preservation.
+
+_cmd_init used to rebuild config.json from a hardcoded whitelist of six keys
+(storage, embeddings, transport, drop_folder, auto_sources, sources), so any
+other top-level key -- notably the documented `summarize` block (model,
+base_url, messages_per_segment, api_key) written by `mychatarchive
+summarize` -- was silently deleted on the next `init` run. It now starts
+from the existing config and only fills in the keys it manages, so unknown
+top-level keys always survive.
+"""
+
+import json
+
+from mychatarchive import cli
+
+
+def _run_init_noninteractive(monkeypatch):
+    """Run _cmd_init with every prompt accepting its default (empty input)."""
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "")
+    cli._cmd_init()
+
+
+def test_init_preserves_summarize_and_unknown_keys(tmp_path, monkeypatch, capsys):
+    import mychatarchive.config as config_mod
+
+    config_file = tmp_path / "config.json"
+    original = {
+        "storage": {"backend": "sqlite", "path": str(tmp_path / "archive.db")},
+        "embeddings": {"backend": "local"},
+        "transport": {"type": "stdio"},
+        "drop_folder": str(tmp_path / "imports"),
+        "auto_sources": {"claude_code": True, "cursor": True},
+        "sources": {},
+        "summarize": {
+            "api_key": "sk-test-placeholder-key",
+            "model": "project-x/test-model",
+            "base_url": "https://example.test/api/v1",
+            "messages_per_segment": 15,
+        },
+        # Stand-in for any future top-level key init doesn't know about --
+        # e.g. a setting added by a later feature. It must survive too.
+        "future_feature_block": {"enabled": True, "note": "unrelated to init"},
+    }
+    config_file.write_text(json.dumps(original))
+    monkeypatch.setattr(config_mod, "get_config_path", lambda: config_file)
+
+    _run_init_noninteractive(monkeypatch)
+    capsys.readouterr()
+
+    saved = json.loads(config_file.read_text())
+    assert saved["summarize"] == original["summarize"]
+    assert saved["future_feature_block"] == original["future_feature_block"]
+    # The keys init does manage are still present and sane.
+    assert saved["storage"]["backend"] == "sqlite"
+    assert saved["drop_folder"] == str(tmp_path / "imports")
+
+
+def test_init_on_fresh_config_still_sets_managed_defaults(tmp_path, monkeypatch, capsys):
+    """No pre-existing config.json: init must still populate the keys it manages."""
+    import mychatarchive.config as config_mod
+
+    config_file = tmp_path / "config.json"  # does not exist yet
+    monkeypatch.setattr(config_mod, "get_config_path", lambda: config_file)
+    monkeypatch.setattr(
+        config_mod, "_DEFAULT_DROP_FOLDER", str(tmp_path / "imports"), raising=False
+    )
+    # _cmd_init imports _DEFAULT_DROP_FOLDER by value at call time from the
+    # config module, so patch it there before _cmd_init's local import runs.
+
+    _run_init_noninteractive(monkeypatch)
+    capsys.readouterr()
+
+    saved = json.loads(config_file.read_text())
+    for key in ("storage", "embeddings", "transport", "drop_folder", "auto_sources", "sources"):
+        assert key in saved
+    assert "summarize" not in saved  # nothing to preserve, nothing invented

--- a/tests/test_mychatarchive_plugin.py
+++ b/tests/test_mychatarchive_plugin.py
@@ -756,6 +756,47 @@ class TestSensitivityScope:
         entry = next(f for f in schema if f["key"] == "include_private")
         assert entry["default"] == "false"
 
+    def test_no_retrieval_call_site_ever_requests_sealed(self, mock_mca):
+        """End-to-end regression: exercise every code path that reaches
+        mychatarchive.db (prefetch, both mca_search modes, all three
+        mca_recall layers, mca_provenance's chunk branch) with the
+        strongest widening the plugin has (include_private=True), and
+        assert every single db call that accepts a scope both received one
+        and that it never contains "sealed". This is what the task
+        actually requires ("NEVER returns sealed even with [include_private]
+        enabled") -- checking provider._scope()'s return value alone (see
+        test_sealed_never_reachable_even_if_include_private_forced) proves
+        the helper is correct but not that every call site actually uses
+        it; a single call site missing `scope=` wouldn't be caught by that
+        test, or by the whole-file negative control, since the file would
+        still run and most assertions would still pass on the calls that
+        do pass scope.
+        """
+        provider, db, _, _ = mock_mca
+        provider._include_private = True
+
+        provider.prefetch("q")
+        provider.handle_tool_call("mca_search", {"query": "q", "mode": "hybrid"})
+        provider.handle_tool_call("mca_recall", {"topic": "q"})
+        provider.handle_tool_call("mca_provenance", {"chunk_id": "chunk-1"})
+
+        scoped_fns = (
+            db.search_chunks, db.get_chunk_by_id, db.fts_search,
+            db.search_thread_summaries, db.get_summary_by_id,
+            db.search_thoughts, db.get_thought_by_id, db.get_thread_summary,
+        )
+        checked = 0
+        for fn in scoped_fns:
+            for call in fn.call_args_list:
+                scope = call.kwargs.get("scope")
+                assert scope is not None, f"{fn._mock_name or fn} called without scope="
+                assert "sealed" not in scope, f"{fn._mock_name or fn} requested sealed scope"
+                checked += 1
+        assert checked >= len(scoped_fns), (
+            "expected at least one recorded call per scoped function -- "
+            "the exercised code paths above should hit all eight"
+        )
+
     def test_coerce_bool_handles_json_and_string_forms(self, mock_mca):
         mod = _plugin_module()
         assert mod._coerce_bool(True) is True

--- a/tests/test_mychatarchive_plugin.py
+++ b/tests/test_mychatarchive_plugin.py
@@ -35,19 +35,19 @@ def _make_mock_db():
         ("chunk-1", 0.3),
         ("chunk-2", 0.6),
     ]
-    db.get_chunk_by_id.side_effect = lambda con, cid: {
+    db.get_chunk_by_id.side_effect = lambda con, cid, **kw: {
         "chunk-1": ("First chunk text about projects", "thread-1", "2026-01-01T00:00:00Z", "2026-01-01T00:01:00Z", '{"platform": "chatgpt", "title": "Project Chat"}'),
         "chunk-2": ("Second chunk about Python", "thread-2", "2026-02-01T00:00:00Z", "2026-02-01T00:01:00Z", '{"platform": "anthropic", "title": "Python Help"}'),
     }.get(cid)
     db.search_thread_summaries.return_value = [("summary-1", 0.4)]
-    db.get_summary_by_id.side_effect = lambda con, sid: {
+    db.get_summary_by_id.side_effect = lambda con, sid, **kw: {
         "summary-1": ("summary-1", "thread-1", 0, "Project Chat", "chatgpt", 10, "2026-01-01", "2026-01-02", "Discussion about projects", '["projects", "planning"]'),
     }.get(sid)
     db.search_thoughts.return_value = [("thought-1", 0.2)]
-    db.get_thought_by_id.side_effect = lambda con, tid: {
+    db.get_thought_by_id.side_effect = lambda con, tid, **kw: {
         "thought-1": ("A captured thought", "2026-03-01T00:00:00Z", '{"source": "hermes"}'),
     }.get(tid)
-    db.get_thread_summary.side_effect = lambda con, tid: {
+    db.get_thread_summary.side_effect = lambda con, tid, **kw: {
         "thread-1": ("summary-1", "thread-1", 0, "Project Chat", "chatgpt", 10, "2026-01-01", "2026-01-02", "Discussion about projects", '["projects"]'),
     }.get(tid)
     db.fts_search.return_value = [
@@ -140,6 +140,12 @@ def mock_mca(tmp_path):
         sys.modules["tools.registry"].tool_error = lambda msg, **kw: json.dumps({"error": msg})
 
         spec.loader.exec_module(mod)
+        # module_from_spec() does not register the module in sys.modules by
+        # itself; do it explicitly so tests can look up the real module
+        # (e.g. to call its module-level helpers) instead of accidentally
+        # matching one of the MagicMock stand-ins patched in above, whose
+        # hasattr() checks are vacuously true for any attribute name.
+        sys.modules["plugins.memory.mychatarchive"] = mod
 
         provider = mod.MyChatArchiveProvider()
 
@@ -676,3 +682,160 @@ class TestEmbeddingDimensionCheck:
         # Should raise when dimensions differ
         with pytest.raises(RuntimeError, match="Embedding dimension mismatch"):
             mod._validate_embedding_dimension(mock_con, 768)
+
+
+# ---------------------------------------------------------------------------
+# Sensitivity scope: the plugin calls mychatarchive.db directly (bypassing
+# the MCP server), so it must enforce fail-closed scope itself. Regression
+# coverage for: retrieval calls used to omit `scope=` entirely, which
+# defaulted to public-only with no opt-in and no visible error -- a user's
+# own agent would silently lose access to their private content the moment
+# they classified it. Sealed must remain unreachable no matter what.
+# ---------------------------------------------------------------------------
+
+
+def _plugin_module():
+    # Loaded under this fixed name by the mock_mca fixture's
+    # spec_from_file_location call. Look it up directly rather than
+    # scanning sys.modules by substring -- several sys.modules entries in
+    # this fixture (e.g. "mychatarchive" itself) are MagicMocks whose
+    # hasattr() checks are vacuously true for any attribute name.
+    mod = sys.modules.get("plugins.memory.mychatarchive")
+    if mod is None or not hasattr(mod, "_coerce_bool"):
+        raise AssertionError("Real plugin module not found in sys.modules")
+    return mod
+
+
+class TestSensitivityScope:
+    def test_default_scope_is_public_only(self, mock_mca):
+        provider, db, _, _ = mock_mca
+        assert provider._include_private is False  # __init__ default
+        provider.handle_tool_call("mca_search", {"query": "test"})
+        assert db.search_chunks.call_args.kwargs.get("scope") == ("public",)
+
+    def test_include_private_widens_search_scope(self, mock_mca):
+        provider, db, _, _ = mock_mca
+        provider._include_private = True
+        provider.handle_tool_call("mca_search", {"query": "test", "mode": "hybrid"})
+        assert db.search_chunks.call_args.kwargs.get("scope") == ("public", "private")
+        assert db.fts_search.call_args.kwargs.get("scope") == ("public", "private")
+
+    def test_recall_threads_scope_through_all_three_layers(self, mock_mca):
+        provider, db, _, _ = mock_mca
+        provider._include_private = True
+        provider.handle_tool_call("mca_recall", {"topic": "test"})
+        assert db.search_chunks.call_args.kwargs.get("scope") == ("public", "private")
+        assert db.search_thread_summaries.call_args.kwargs.get("scope") == ("public", "private")
+        assert db.search_thoughts.call_args.kwargs.get("scope") == ("public", "private")
+
+    def test_prefetch_threads_scope(self, mock_mca):
+        provider, db, _, _ = mock_mca
+        provider.prefetch("query")
+        assert db.search_chunks.call_args.kwargs.get("scope") == ("public",)
+        provider._include_private = True
+        provider.prefetch("query")
+        assert db.search_chunks.call_args.kwargs.get("scope") == ("public", "private")
+
+    def test_sealed_never_reachable_even_if_include_private_forced(self, mock_mca):
+        # There is no config value or parameter that can add "sealed" to
+        # scope -- _scope() filters through _PLUGIN_ALLOWED_LEVELS, which
+        # only lists public/private. Forcing include_private (the strongest
+        # widening available) must still never surface sealed.
+        provider, _, _, _ = mock_mca
+        provider._include_private = True
+        assert "sealed" not in provider._scope()
+        assert set(provider._scope()) <= {"public", "private"}
+
+    def test_plugin_allowed_levels_excludes_sealed(self, mock_mca):
+        mod = _plugin_module()
+        assert "sealed" not in mod._PLUGIN_ALLOWED_LEVELS
+
+    def test_config_schema_includes_include_private_default_false(self, mock_mca):
+        provider, _, _, _ = mock_mca
+        schema = provider.get_config_schema()
+        entry = next(f for f in schema if f["key"] == "include_private")
+        assert entry["default"] == "false"
+
+    def test_coerce_bool_handles_json_and_string_forms(self, mock_mca):
+        mod = _plugin_module()
+        assert mod._coerce_bool(True) is True
+        assert mod._coerce_bool(False) is False
+        assert mod._coerce_bool("true") is True
+        assert mod._coerce_bool("false") is False
+        assert mod._coerce_bool("1") is True
+        assert mod._coerce_bool("0") is False
+        assert mod._coerce_bool(None) is False
+        assert mod._coerce_bool("") is False
+
+
+class TestProvenanceHonesty:
+    """mca_provenance used to report a flat 'not found' for both a
+    genuinely-absent row and a row that exists but is outside scope
+    (private, with include_private off) -- telling the user their data
+    was lost when it was merely restricted."""
+
+    def test_private_chunk_reports_restricted_not_missing(self, mock_mca):
+        provider, db, _, _ = mock_mca
+        provider._include_private = False
+
+        def side_effect(con, cid, **kw):
+            if cid != "priv-chunk":
+                return None
+            # Absent at the plugin's own (public-only) scope, present once
+            # widened to public+private -- i.e. genuinely exists, just private.
+            if kw.get("scope") == ("public",):
+                return None
+            return ("private text", "thread-9", "2026-01-01", "2026-01-01", "{}")
+
+        db.get_chunk_by_id.side_effect = side_effect
+        result = json.loads(provider.handle_tool_call(
+            "mca_provenance", {"chunk_id": "priv-chunk"},
+        ))
+        assert "error" in result
+        assert "private" in result["error"].lower()
+        assert "not found" not in result["error"].lower()
+
+    def test_genuinely_missing_chunk_still_reports_not_found(self, mock_mca):
+        provider, db, _, _ = mock_mca
+        provider._include_private = False
+        db.get_chunk_by_id.side_effect = lambda con, cid, **kw: None
+        result = json.loads(provider.handle_tool_call(
+            "mca_provenance", {"chunk_id": "ghost-chunk"},
+        ))
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_private_thought_reports_restricted_not_missing(self, mock_mca):
+        provider, db, _, _ = mock_mca
+        provider._include_private = False
+
+        def side_effect(con, tid, **kw):
+            if tid != "priv-thought":
+                return None
+            if kw.get("scope") == ("public",):
+                return None
+            return ("private thought text", "2026-01-01", "{}")
+
+        db.get_thought_by_id.side_effect = side_effect
+        result = json.loads(provider.handle_tool_call(
+            "mca_provenance", {"thought_id": "priv-thought"},
+        ))
+        assert "error" in result
+        assert "private" in result["error"].lower()
+        assert "not found" not in result["error"].lower()
+
+    def test_include_private_on_returns_content_directly_no_restriction_message(self, mock_mca):
+        provider, db, _, _ = mock_mca
+        provider._include_private = True
+
+        def side_effect(con, cid, **kw):
+            if cid == "priv-chunk" and kw.get("scope") == ("public", "private"):
+                return ("private text", "thread-9", "2026-01-01", "2026-01-01", "{}")
+            return None
+
+        db.get_chunk_by_id.side_effect = side_effect
+        result = json.loads(provider.handle_tool_call(
+            "mca_provenance", {"chunk_id": "priv-chunk"},
+        ))
+        assert result.get("type") == "chunk"
+        assert result.get("text") == "private text"

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -321,3 +321,53 @@ def test_reconcile_raises_new_rows_to_thread_level(env):
     # All-public threads are never touched, and reconcile never lowers levels
     assert store.reconcile_thread_sensitivity(con) == 0
     assert store.get_thread_sensitivity(con, "pub") == ("public", 1)
+
+
+# ── Uncapped thread-id lookup for bulk classification (bug: 10k row cap) ──────
+
+def test_fts_search_thread_ids_scoped(env):
+    con, *_ = env
+    _seed_three_levels(con)
+    ids = set(store.fts_search_thread_ids(con, "SECRET"))
+    assert ids == {"pub"}
+    ids = set(store.fts_search_thread_ids(con, "SECRET", scope=("public", "private")))
+    assert ids == {"pub", "priv"}
+    ids = set(store.fts_search_thread_ids(con, "SECRET", scope=store.SENSITIVITY_LEVELS))
+    assert ids == {"pub", "priv", "seal"}
+
+
+def test_fts_search_thread_ids_empty_group_set_returns_nothing(env):
+    con, *_ = env
+    _seed_three_levels(con)
+    assert store.fts_search_thread_ids(con, "SECRET", group_thread_ids=set(),
+                                       scope=store.SENSITIVITY_LEVELS) == []
+
+
+def test_fts_search_thread_ids_covers_every_matching_thread_beyond_any_row_cap(env):
+    """Regression for the classify --query row cap: a message-row-limited
+    search (the old ``fts_search(..., limit=N)`` approach) can silently miss
+    threads whose matches fall outside the cap, even though thread count is
+    far smaller than message count. The dedicated thread-id lookup must
+    return every matching thread regardless of how many messages match.
+
+    N=25 threads is a synthetic stand-in for "more threads than any row cap"
+    -- the assertion pattern (row-limited search misses threads that the
+    uncapped lookup finds) is what would have failed against the real
+    limit=10000 cap on a large archive; testing at N=10000 would just make
+    this test slow without proving anything more.
+    """
+    con, *_ = env
+    n = 25
+    cap = 10
+    for i in range(n):
+        _msg(con, f"m-{i}", f"thread-{i}", "WIDGET rollout notes")
+
+    # Old approach: derive thread ids from a row-limited message search.
+    capped_rows = store.fts_search(con, "WIDGET", limit=cap, scope=store.SENSITIVITY_LEVELS)
+    capped_thread_ids = {row[2] for row in capped_rows}
+    assert len(capped_rows) == cap
+    assert len(capped_thread_ids) < n  # some threads silently dropped by the cap
+
+    # New approach: dedicated uncapped thread-id lookup finds all of them.
+    all_thread_ids = set(store.fts_search_thread_ids(con, "WIDGET", scope=store.SENSITIVITY_LEVELS))
+    assert all_thread_ids == {f"thread-{i}" for i in range(n)}


### PR DESCRIPTION
Four findings from the post-v0.4.0 review. One of them means the package is **currently broken for new installs** — see #3.

## 1. `classify --query` silently missed threads (HIGH)

Bulk classification derived its thread list from `fts_search(..., limit=10000)`. On an archive where a keyword matches more messages than that cap, threads whose matches fell outside the bm25 top-10000 were never classified — with no warning. The user believes everything matching is sealed; some of it is still public and still served to agents. A silent coverage gap in a privacy feature is the worst place to have one.

**Fix:** new `fts_search_thread_ids()` selects `DISTINCT canonical_thread_id` with no row limit — bounded by thread count rather than match count, so it stays cheap — layered properly through `sqlite.py` → `db.py` → the `StorageBackend` protocol. `classify --query` now uses it.

Cost note: the preview loop still issues one `get_thread_sensitivity` query per matched thread and is no longer bounded by the old cap. Correct-over-fast, but not free on a very large archive.

## 2. `init` destroyed the `summarize` config block, including a stored API key (HIGH)

`_cmd_init` rebuilt `config.json` from a hardcoded six-key whitelist and saved over the file, so any top-level key it didn't know about vanished on every re-run. The documented `summarize` block (model, base_url, messages_per_segment, api_key) was not in that whitelist.

**Fix:** start from the existing config and `setdefault` only the keys init actually manages. Unknown keys now survive structurally rather than by remembering to extend a list — the CLAUDE.md bullet that documented the old trap is updated to match.

## 3. Dependency range let pip install a broken combination (HIGH)

`mcp[cli]>=1.0.0` was wrong at both ends:

- **Floor too low:** `mcp.server.fastmcp` only exists from 1.2.0, and `mcp.settings.transport_security` (used by the TLS serve path) from 1.10.0.
- **No cap, and this is the urgent part:** `mcp` 2.0.0 is released and removed `mcp.server.fastmcp` entirely (FastMCP moved to `mcp.server.mcpserver`, and transport params moved from the settings object onto call arguments). A fresh `pip install mychatarchive` today resolves 2.0.0 and **fails at import**, not just on the TLS path.

**Fix:** `mcp[cli]>=1.10.0,<2.0.0`, with the reasoning recorded inline. Verified independently by inspecting the published 2.0.0 wheel: zero `fastmcp` entries, `mcp/server/mcpserver` present.

Supporting 2.x is a real piece of work (import path plus transport-parameter changes) and belongs in its own PR.

## 4. The Hermes plugin lost private content with no way to opt in (HIGH)

The plugin calls `mychatarchive.db` directly, bypassing the MCP server, so v0.4.0's fail-closed default silently restricted it to public content. A user who classified personal threads `private` — intending to hide them from *shared* surfaces — found their own agent returning nothing, with no error and no config knob.

**Fix:** `include_private` in the plugin config schema (default `false`, fail-closed), threaded through all 14 direct db calls. Sealed remains structurally unreachable via the same allowlist pattern the MCP server uses — no config value can widen scope to include it. Also fixed `mca_provenance`, which reported "not found" for rows that exist but are out of scope, telling users their data was lost when it was merely restricted.

Known gap: the interactive Hermes setup wizard doesn't prompt for `include_private`; it must be set in config. Config writes merge rather than overwrite, so nothing is at risk.

## Verification

155 tests pass (20 new). Each fix reverted in isolation to confirm its tests fail, verified independently. Ruff error count identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)