### PR TITLE
fix: loopback-only SSE bind, UTF-8 config I/O, and quieter parser logging

### DIFF
--- a/src/mychatarchive/cli.py
+++ b/src/mychatarchive/cli.py
@@ -292,6 +292,16 @@ def main():
         help="Port for SSE transport (default: 8420)",
     )
     serve_p.add_argument(
+        "--host",
+        default="127.0.0.1",
+        metavar="ADDRESS",
+        help=(
+            "Bind address for SSE transport (default: 127.0.0.1, localhost only). "
+            "Pass 0.0.0.0 to accept LAN connections -- only do this alongside "
+            "--ssl-certfile/--ssl-keyfile."
+        ),
+    )
+    serve_p.add_argument(
         "--ssl-certfile",
         default=None,
         metavar="PATH",
@@ -1188,6 +1198,7 @@ def _cmd_serve(args, db_path: Path):
         port=args.port,
         ssl_certfile=getattr(args, "ssl_certfile", None),
         ssl_keyfile=getattr(args, "ssl_keyfile", None),
+        host=getattr(args, "host", None),
     )
 
 

--- a/src/mychatarchive/config.py
+++ b/src/mychatarchive/config.py
@@ -71,7 +71,7 @@ def load_config() -> dict:
     path = get_config_path()
     if path.exists():
         try:
-            return json.loads(path.read_text())
+            return json.loads(path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             return {}
     return {}
@@ -80,7 +80,7 @@ def load_config() -> dict:
 def save_config(cfg: dict):
     path = get_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(cfg, indent=2))
+    path.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
 
 
 def get_embedding_model() -> str:

--- a/src/mychatarchive/mcp/server.py
+++ b/src/mychatarchive/mcp/server.py
@@ -522,8 +522,17 @@ def get_profile(
     return json.dumps(out, indent=2)
 
 
+# Default bind address for SSE transport: loopback-only. Binding every
+# interface is an explicit, caller-provided opt-in (CLI: `serve --host
+# <bind-all-address>`), never a hardcoded default -- a fixed bind-all literal
+# would bind every archive-serving process to the LAN whether or not the
+# operator wanted that.
+_DEFAULT_SSE_HOST = "127.0.0.1"
+
+
 def run(db_path: Path | None = None, transport: str = "stdio", port: int = 8420,
-        ssl_certfile: str | None = None, ssl_keyfile: str | None = None):
+        ssl_certfile: str | None = None, ssl_keyfile: str | None = None,
+        host: str | None = None):
     """Start the MCP server."""
     if db_path:
         global _con
@@ -531,20 +540,28 @@ def run(db_path: Path | None = None, transport: str = "stdio", port: int = 8420,
         _ensure_migrated(_con)
 
     if transport == "sse":
-        print(f"Starting MCP server with SSE transport on port {port}", file=sys.stderr)
+        bind_host = host or _DEFAULT_SSE_HOST
+        print(
+            f"Starting MCP server with SSE transport on {bind_host}:{port}",
+            file=sys.stderr,
+        )
         mcp.settings.port = port
+        mcp.settings.host = bind_host
         if ssl_certfile or ssl_keyfile:
             import anyio
             import uvicorn
 
-            # Disable localhost-only DNS rebinding protection so LAN clients can connect.
-            # Safe here because we're using a proper mkcert cert over HTTPS on a private LAN.
-            mcp.settings.transport_security.enable_dns_rebinding_protection = False
+            # Disable localhost-only DNS rebinding protection only when the
+            # caller explicitly asked for a non-loopback bind (CLI: --host
+            # <bind-all>) -- a proper mkcert cert over HTTPS on a private LAN
+            # is the intended use; the loopback-only default keeps it on.
+            if bind_host != _DEFAULT_SSE_HOST:
+                mcp.settings.transport_security.enable_dns_rebinding_protection = False
 
             async def _run():
                 config = uvicorn.Config(
                     mcp.sse_app(),
-                    host="0.0.0.0",
+                    host=bind_host,
                     port=port,
                     log_level=mcp.settings.log_level.lower(),
                     ssl_certfile=ssl_certfile,

--- a/src/mychatarchive/parsers/anthropic.py
+++ b/src/mychatarchive/parsers/anthropic.py
@@ -1,9 +1,12 @@
 """Parser for Anthropic Claude conversation exports."""
 
+import logging
 from datetime import datetime
 from typing import Iterator
 
 import ijson
+
+logger = logging.getLogger(__name__)
 
 
 def parse(input_path: str) -> Iterator[dict]:
@@ -47,7 +50,10 @@ def _parse_conversation(convo: dict) -> Iterator[dict]:
         try:
             dt = datetime.fromisoformat(created_at_str.replace("Z", "+00:00"))
             created_at = dt.timestamp()
-        except (ValueError, TypeError, AttributeError):
+        except (ValueError, TypeError, AttributeError) as exc:
+            logger.debug(
+                "Unparseable created_at %r in thread %r: %s", created_at_str, thread_id, exc,
+            )
             created_at = 0.0
 
         yield {

--- a/src/mychatarchive/parsers/claude_code.py
+++ b/src/mychatarchive/parsers/claude_code.py
@@ -1,11 +1,14 @@
 """Parser for Claude Code conversation history (~/.claude/projects/)."""
 
 import json
+import logging
 import os
 import platform
 from datetime import datetime
 from pathlib import Path
 from typing import Iterator
+
+logger = logging.getLogger(__name__)
 
 
 def _default_claude_dir() -> Path:
@@ -31,8 +34,8 @@ def _discover_sessions(claude_dir: Path) -> list[dict]:
             try:
                 with open(index_path, "r", encoding="utf-8") as f:
                     index_data = json.load(f)
-            except (json.JSONDecodeError, OSError):
-                pass
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.debug("Skipping unreadable sessions index %s: %s", index_path, exc)
 
         entries_by_id = {}
         for entry in index_data.get("entries", []):

--- a/src/mychatarchive/parsers/cursor.py
+++ b/src/mychatarchive/parsers/cursor.py
@@ -13,12 +13,15 @@ Cursor stores conversations in two SQLite databases:
 """
 
 import json
+import logging
 import os
 import platform
 import sqlite3
 from datetime import datetime
 from pathlib import Path
 from typing import Iterator
+
+logger = logging.getLogger(__name__)
 
 
 def _default_cursor_dir() -> Path:
@@ -99,8 +102,8 @@ def _read_composers_from_global(global_db_path: Path) -> dict[str, dict]:
                     ws_data = json.load(f)
                 folder_uri = ws_data.get("folder", "")
                 workspace_folder = _uri_to_path(folder_uri)
-            except (json.JSONDecodeError, OSError):
-                pass
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.debug("Skipping unreadable workspace.json %s: %s", ws_json, exc)
 
         try:
             con = sqlite3.connect(f"file:{ws_db}?mode=ro", uri=True)

--- a/src/mychatarchive/summarizer.py
+++ b/src/mychatarchive/summarizer.py
@@ -34,7 +34,7 @@ import urllib.request
 from pathlib import Path
 
 try:
-    from tqdm import tqdm
+    from tqdm import tqdm  # noqa: F401 -- availability probe; re-imported where used below
     _HAS_TQDM = True
 except ImportError:
     _HAS_TQDM = False
@@ -86,7 +86,7 @@ def _segment_messages(messages: list[dict], per_segment: int) -> list[list[dict]
 
 def _segment_ts(messages: list[dict]) -> tuple[str | None, str | None]:
     """Return (ts_start, ts_end) for a list of messages."""
-    timestamps = [m.get("ts") for m in messages if m.get("ts")]
+    timestamps = [str(t) for m in messages if (t := m.get("ts"))]
     if not timestamps:
         return None, None
     return min(timestamps), max(timestamps)
@@ -255,7 +255,11 @@ def run(
                   file=sys.stderr)
 
     processed = errors = total_segments = 0
-    iterator = tqdm(threads, desc="Summarizing", unit="thread") if _HAS_TQDM else threads
+    if _HAS_TQDM:
+        from tqdm import tqdm  # re-import: keeps type checkers from seeing tqdm as possibly unbound
+        iterator = tqdm(threads, desc="Summarizing", unit="thread")
+    else:
+        iterator = threads
 
     for thread_meta in iterator:
         thread_id = thread_meta["canonical_thread_id"]


### PR DESCRIPTION
### What

- **Security**: the SSE transport hardcoded `host="0.0.0.0"` whenever a TLS
  cert was configured, binding the archive server to every network
  interface with no way to opt out. `serve` now defaults to `127.0.0.1`
  and only binds elsewhere when `--host` is passed explicitly; DNS-rebinding
  protection is only relaxed when a non-loopback host was explicitly
  requested.
- **Encoding**: `config.py`'s `read_text()`/`write_text()` calls didn't pin
  an encoding, so they fall back to `locale.getpreferredencoding()` — the
  config file is JSON and should round-trip identically regardless of the
  host locale (this bites hardest on Windows, where the default is
  `cp1252`, not UTF-8).
- **Parser logging**: the `anthropic`, `claude_code`, and `cursor` parsers
  each catch a parse error on one record/file inside an import loop and
  continue — the right behavior, since one corrupt session shouldn't abort
  a whole import. But the `except: pass` made a clean import indistinguishable
  from one that silently skipped files. Logs the skip at `DEBUG` level;
  control flow is unchanged.
- **Type correctness**: `summarizer._segment_ts` built its timestamp list
  from plain `.get("ts")` (typed `str | None`), then called `min()`/`max()`
  over it — unsound under a type checker and, if a `None` ever slipped
  through, an unsound-at-runtime comparison too. Filters and coerces to
  `str` explicitly. Also re-imports `tqdm` inside the `if _HAS_TQDM:` branch
  so the name isn't "possibly unbound" at the point of use under a type
  checker's view of the `try/except ImportError` guard.

### Why

These came out of hardening a downstream fork; the security fix is
independently worth landing regardless of the rest.

### How tested

`pytest` (135 tests) against a clean `uv venv` + `pip install -e ".[dev]"`
checkout — passing, no change in pass count. `ruff check src/` before/after
the patch produces the same 80 pre-existing findings (0 introduced,
0 fixed — this PR doesn't touch those).

Manual checks:
- `python -m mychatarchive serve --help` shows the new `--host` flag with
  its default and warning text.
- Confirmed the vulnerable pattern at the pre-fix commit
  (`git show <base>:src/mychatarchive/mcp/server.py`) hardcodes
  `host="0.0.0.0"` unconditionally in the TLS branch — the exact case this
  PR's first commit changes.

### Note on `mcp` dependency version

`pyproject.toml` pins `mcp[cli]>=1.0.0` unbounded. A plain
`uv pip install -e ".[dev]"` today resolves `mcp==2.1.1`, whose
`mcp.server.fastmcp` import path was removed/renamed
(`ModuleNotFoundError`, points at `mcp.server.mcpserver.MCPServer`) — the
package doesn't currently install and run against latest `mcp` without a
compatibility shim. That's out of scope for this PR (it's a separate,
larger migration decision for whichever `mcp` API surface upstream wants
to target), but it's worth knowing: the test run above only succeeded
after pinning `mcp[cli]<2` locally for verification.

### Commits

- `fix(security): default SSE transport to loopback-only bind`
- `fix: pin config.json reads/writes to UTF-8`
- `fix(parsers): log skipped/corrupt files at debug level instead of swallowing`
- `fix(summarizer): type-correctness fixes in segment timestamps and tqdm import`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
